### PR TITLE
Add cross-platform icon support for Android and Web

### DIFF
--- a/app/(onboarding)/welcome.tsx
+++ b/app/(onboarding)/welcome.tsx
@@ -1,6 +1,6 @@
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
-import { IconSymbol } from '@/components/ui/icon-symbol';
+import { IconSymbol, IconSymbolName } from '@/components/ui/icon-symbol';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
@@ -10,7 +10,7 @@ export default function WelcomeScreen() {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
 
-  const features = [
+  const features: { icon: IconSymbolName; title: string; description: string }[] = [
     {
       icon: 'heart.fill',
       title: 'Track Your Vibes',

--- a/app/(tabs)/contacts.tsx
+++ b/app/(tabs)/contacts.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { StyleSheet, ScrollView, View, Pressable, Linking, Alert } from 'react-native';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
-import { IconSymbol } from '@/components/ui/icon-symbol';
+import { IconSymbol, IconSymbolName } from '@/components/ui/icon-symbol';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { AccountButton } from '@/components/account/account-button';
 import { AccountSheet } from '@/components/account/account-sheet';
@@ -10,7 +10,7 @@ import { useAccount } from '@spezivibe/account';
 
 interface ContactOption {
   type: 'call' | 'text' | 'email' | 'website';
-  icon: string;
+  icon: IconSymbolName;
   label: string;
   value: string;
 }
@@ -21,7 +21,7 @@ interface Contact {
   title: string;
   organization: string;
   description: string;
-  icon: string;
+  icon: IconSymbolName;
   options: ContactOption[];
 }
 

--- a/components/ui/icon-symbol.ios.tsx
+++ b/components/ui/icon-symbol.ios.tsx
@@ -1,6 +1,9 @@
 import { SymbolView, SymbolViewProps, SymbolWeight } from 'expo-symbols';
 import { StyleProp, ViewStyle } from 'react-native';
 
+// Export the type for use in other components (matches the non-iOS version)
+export type IconSymbolName = SymbolViewProps['name'];
+
 export function IconSymbol({
   name,
   size = 24,
@@ -8,7 +11,7 @@ export function IconSymbol({
   style,
   weight = 'regular',
 }: {
-  name: SymbolViewProps['name'];
+  name: IconSymbolName;
   size?: number;
   color: string;
   style?: StyleProp<ViewStyle>;

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -1,12 +1,11 @@
 // Fallback for using MaterialIcons on Android and web.
 
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
+import { SymbolWeight } from 'expo-symbols';
 import { ComponentProps } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
-type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
-type IconSymbolName = keyof typeof MAPPING;
+type MaterialIconName = ComponentProps<typeof MaterialIcons>['name'];
 
 /**
  * Add your SF Symbols to Material Icons mappings here.
@@ -14,11 +13,41 @@ type IconSymbolName = keyof typeof MAPPING;
  * - see SF Symbols in the [SF Symbols](https://developer.apple.com/sf-symbols/) app.
  */
 const MAPPING = {
+  // Navigation & Tabs
   'house.fill': 'home',
+  'calendar': 'event',
+  'person.2.fill': 'people',
   'paperplane.fill': 'send',
+
+  // UI Elements
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
-} as IconMapping;
+  'checkmark': 'check',
+  'checkmark.circle.fill': 'check-circle',
+  'info.circle.fill': 'info',
+
+  // Features & Welcome
+  'heart.fill': 'favorite',
+  'chart.line.uptrend.xyaxis': 'trending-up',
+  'bell.badge.fill': 'notifications',
+  'sparkles': 'auto-awesome',
+  'lock.shield.fill': 'security',
+  'star.fill': 'star',
+
+  // Contacts & Communication
+  'person.circle.fill': 'account-circle',
+  'phone.fill': 'phone',
+  'message.fill': 'chat',
+  'envelope.fill': 'email',
+  'questionmark.circle.fill': 'help',
+  'safari.fill': 'language',
+  'exclamationmark.triangle.fill': 'warning',
+
+  // Documents
+  'doc.text.fill': 'description',
+} satisfies Record<string, MaterialIconName>;
+
+export type IconSymbolName = keyof typeof MAPPING;
 
 /**
  * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.


### PR DESCRIPTION
This PR adds Material Icons mappings for all SF Symbols used in the app, ensuring icons render correctly on Android and Web platforms.
