### PR TITLE
Add project-wiki to docs, zip download, and build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+#
+# This source file is part of the Stanford Spezi open-source project.
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+      - name: Install dependencies
+        working-directory: docs
+        run: npm ci
+      - name: Build
+        working-directory: docs
+        run: npm run build
+
+  validate-skills:
+    name: Validate Skills
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check skill structure
+        run: |
+          status=0
+          for dir in skills/*/; do
+            skill=$(basename "$dir")
+            if [ ! -f "$dir/SKILL.md" ]; then
+              echo "::error::$skill is missing SKILL.md"
+              status=1
+            fi
+          done
+          exit $status

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
 </p>
 
 <p align="center">
-  <a href="https://github.com/StanfordSpezi/SpeziVibe/actions/workflows/static-analysis.yml"><img src="https://img.shields.io/github/actions/workflow/status/StanfordSpezi/SpeziVibe/static-analysis.yml?style=flat-square&label=build" alt="Build Status"/></a>
+  <a href="https://github.com/StanfordSpezi/SpeziVibe/actions/workflows/build.yml"><img src="https://img.shields.io/github/actions/workflow/status/StanfordSpezi/SpeziVibe/build.yml?style=flat-square&label=build" alt="Build Status"/></a>
   <a href="https://github.com/StanfordSpezi/SpeziVibe/releases"><img src="https://img.shields.io/github/v/release/StanfordSpezi/SpeziVibe?label=latest%20release&style=flat-square" alt="Latest Release"/></a>
   <a href="LICENSE.md"><img src="https://img.shields.io/github/license/StanfordSpezi/SpeziVibe?style=flat-square" alt="MIT License"/></a>
 </p>

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -21,6 +21,12 @@ Each skill covers a specific area of digital health planning and produces a stru
 | [fhir-data-model-design](skills/fhir-data-model-design) | Map clinical data to FHIR R4 resources and terminology | `fhir-data-model.md` |
 | [app-build-planner](skills/app-build-planner) | Produce milestone-based implementation plan from planning docs | `implementation-plan.md` |
 
+## Knowledge Management Skills
+
+| Skill | What it does | Output |
+|-------|-------------|--------|
+| [project-wiki](skills/project-wiki) | Set up and maintain an AI-managed knowledge base that compounds over time | `wiki/` directory + schema |
+
 ## Release Skills
 
 | Skill | What it does | Output |

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -5,7 +5,7 @@ slug: /skills
 
 # Skills Overview
 
-Each skill covers a specific area of digital health planning and produces a structured markdown document. Use them individually or let **build-an-app** orchestrate them based on what you describe.
+Each skill covers a specific area of digital health development &mdash; from planning through building and maintenance. Use them individually or let **build-an-app** orchestrate them based on what you describe.
 
 ## Planning Skills
 

--- a/docs/docs/skills/app-build-planner.md
+++ b/docs/docs/skills/app-build-planner.md
@@ -31,6 +31,41 @@ Produces `docs/implementation-plan.md` containing:
 - Data model and compliance integration tables
 - Open questions
 
+## Example
+
+```
+AI:   Which template did you clone — React Native or Spezi
+      Template Application? And which backend — Firebase,
+      Medplum, or something else?
+
+You:  Spezi Template Application with Firebase.
+
+AI:   I've read your planning docs. Here's a proposed milestone
+      sequence:
+
+      Milestone 1: Foundation
+        — Configure Firebase project and authentication
+        — Set up Firestore security rules
+        — Verify build and test pipeline
+        Verification: User can sign in and see empty home screen
+
+      Milestone 2: Onboarding
+        — Implement consent flow using SpeziOnboarding
+        — Add profile setup (name, date of birth)
+        — Request HealthKit permissions
+        Verification: New user completes onboarding and lands on home
+
+      Milestone 3: Medication Tracking
+        — Build medication list view
+        — Implement daily check-in flow
+        — Store adherence data in Firestore
+        Verification: Patient can log medications and see history
+
+      ...8 more milestones...
+
+      Ready to start building Milestone 1?
+```
+
 ## Limitations
 
 - Does not generate application code — only a plan document

--- a/docs/docs/skills/biodesign-needs-finding.md
+++ b/docs/docs/skills/biodesign-needs-finding.md
@@ -21,6 +21,32 @@ Produces `docs/planning/need-statement.md` containing:
 - Key stakeholders to validate with
 - Identified insights about why the need is unmet
 
+## Example
+
+```
+AI:   Do you already have a need statement or draft, or are you
+      starting fresh?
+
+You:  We need an app for cardiac rehab patients
+
+AI:   That sounds like a solution — let's work backward to the
+      underlying problem. What's happening with cardiac rehab
+      patients that isn't working today?
+
+You:  They don't stick with their exercise programs after discharge
+
+AI:   Good — that's the problem space. Which patients specifically?
+      Post-MI? Post-CABG? Heart failure? And at what point after
+      discharge does adherence drop off?
+
+      ...
+
+AI:   Here's your refined need statement:
+      "A way to sustain exercise adherence in post-discharge
+      cardiac rehabilitation patients in order to reduce
+      30-day readmission rates and improve functional recovery."
+```
+
 ## Limitations
 
 - Does not write the statement for you — requires your active participation

--- a/docs/docs/skills/build-an-app.md
+++ b/docs/docs/skills/build-an-app.md
@@ -29,6 +29,26 @@ The orchestrator picks skills based on signals in your description:
 
 Skills are skipped if you already have the corresponding planning document.
 
+## Example
+
+```
+You:  I want to build a medication tracking app for post-transplant patients
+
+AI:   Based on your description, I'd recommend these planning steps:
+      1. biodesign-needs-finding — define the core problem
+      2. digital-health-compliance-planning — HIPAA and medication data
+      3. health-data-model-planning — medication schedules, adherence
+      4. digital-health-ux-planning — patient and caregiver workflows
+      5. app-build-planner — implementation plan with milestones
+
+      Want to proceed with this order?
+
+You:  Yes, let's go
+
+AI:   Starting with needs-finding. What specific problem are
+      post-transplant patients facing with medication adherence?
+```
+
 ## Output
 
 Each skill produces its own document in `docs/planning/`. The final output is an `implementation-plan.md` with milestones, tasks, and dependencies.

--- a/docs/docs/skills/digital-health-compliance-planning.md
+++ b/docs/docs/skills/digital-health-compliance-planning.md
@@ -26,6 +26,36 @@ Produces `docs/planning/compliance-brief.md` containing:
 - Required decisions
 - Recommended controls (access control, encryption, audit logging, consent capture, export/deletion)
 
+## Example
+
+```
+AI:   Before diving into compliance domains — what does the product
+      actually do? Who uses it, and what data does it collect?
+
+You:  It's a cardiac rehab app that tracks exercise, collects
+      patient-reported outcomes, and shares summaries with
+      the care team.
+
+AI:   A few follow-ups:
+      — Is this for a research study or direct clinical care?
+      — Does it recommend exercise intensity or just track it?
+      — Are you at a HIPAA-covered entity like a hospital?
+
+You:  Research study at Stanford. It recommends exercise targets
+      based on the patient's care plan.
+
+AI:   Here's my initial assessment:
+
+      ✅ HIPAA — Likely. PHI at a covered entity.
+      ✅ IRB — Likely. Research study with human subjects.
+      ⚠️ FDA — Possible. Exercise recommendations based on
+         clinical data may qualify as clinical decision support.
+         Needs legal review.
+      ❌ GDPR — Unlikely. US-only participants.
+
+      The FDA question is the one I'd flag to counsel first.
+```
+
 ## Limitations
 
 - **Not legal advice** — distinguishes product guidance from counsel that requires legal review

--- a/docs/docs/skills/digital-health-study-planning.md
+++ b/docs/docs/skills/digital-health-study-planning.md
@@ -19,6 +19,34 @@ Helps plan a digital health research protocol. Platform-agnostic — focuses on 
 
 Produces `docs/planning/study-brief.md`.
 
+## Example
+
+```
+AI:   What's the study objective? And what kind of study are you
+      planning — randomized trial, single-arm, observational?
+
+You:  We want to test whether our app improves exercise adherence
+      in cardiac rehab patients vs. standard of care. Randomized.
+
+AI:   Got it. Who are the participants, and how long do you plan
+      to follow them?
+
+You:  Adults 40-75 who completed phase II cardiac rehab.
+      12 weeks with a 4-week follow-up.
+
+AI:   Here's a draft data collection matrix:
+
+      | Data Type       | Source    | Frequency  | Purpose           |
+      |-----------------|-----------|------------|-------------------|
+      | Step count      | HealthKit | Daily      | Primary outcome   |
+      | Exercise mins   | Self-report | Weekly   | Primary outcome   |
+      | PHQ-9           | In-app    | Biweekly   | Secondary outcome |
+      | App usage       | Analytics | Continuous | Engagement        |
+      | Adverse events  | Clinician | As needed  | Safety            |
+
+      Does this capture what you need? Any missing data types?
+```
+
 ## Limitations
 
 - Does not produce a detailed statistical analysis plan or IRB protocol document

--- a/docs/docs/skills/digital-health-ux-planning.md
+++ b/docs/docs/skills/digital-health-ux-planning.md
@@ -20,6 +20,34 @@ Plans user experience journeys for digital health products. Platform-agnostic �
 
 Produces `docs/planning/ux-brief.md`.
 
+## Example
+
+```
+AI:   Who are the primary users, and what are their core jobs
+      when using this app?
+
+You:  Post-transplant patients tracking their meds, and
+      transplant coordinators reviewing adherence.
+
+AI:   What constraints should we design around? For example —
+      health literacy, fatigue, accessibility needs?
+
+You:  Many patients are older, some have low health literacy,
+      and they're often fatigued post-surgery.
+
+AI:   Here's an onboarding approach for the patient journey:
+
+      1. Welcome — one sentence on what the app does
+      2. Account setup — email/password only, no unnecessary fields
+      3. Medication list — import from care plan or enter manually
+      4. First check-in — mark today's meds as taken (immediate value)
+      5. Permissions — notifications only, deferred to after first use
+
+      I'd defer any health data permissions or detailed profile
+      setup until the patient has used the app for a day or two.
+      Thoughts?
+```
+
 ## Limitations
 
 - Does not produce wireframes or UI mockups

--- a/docs/docs/skills/fhir-data-model-design.md
+++ b/docs/docs/skills/fhir-data-model-design.md
@@ -27,6 +27,43 @@ Plus:
 
 Produces `docs/planning/fhir-data-model.md`.
 
+## Example
+
+```
+AI:   What clinical data does your app track? List every type —
+      vitals, labs, questionnaires, medications, conditions.
+
+You:  Blood pressure, heart rate, daily step count, and a
+      weekly PHQ-9 depression screening.
+
+AI:   Based on that, here's the FHIR resource mapping:
+
+      Blood pressure → Observation (US Core Blood Pressure profile)
+        LOINC: 85354-9, components: systolic 8480-6, diastolic 8462-4
+
+      Heart rate → Observation (US Core Heart Rate profile)
+        LOINC: 8867-4
+
+      Step count → Observation
+        LOINC: 55423-8
+
+      PHQ-9 → QuestionnaireResponse + Observation (score)
+        Questionnaire canonical: http://loinc.org/q/44249-1
+        Score LOINC: 44261-6
+
+      Sample FHIR JSON for a blood pressure reading:
+      {
+        "resourceType": "Observation",
+        "status": "final",
+        "category": [{"coding": [{"system": "http://terminology.hl7.org/CodeSystem/observation-category", "code": "vital-signs"}]}],
+        "code": {"coding": [{"system": "http://loinc.org", "code": "85354-9"}]},
+        "component": [
+          {"code": {"coding": [{"system": "http://loinc.org", "code": "8480-6"}]}, "valueQuantity": {"value": 120, "unit": "mmHg"}},
+          {"code": {"coding": [{"system": "http://loinc.org", "code": "8462-4"}]}, "valueQuantity": {"value": 80, "unit": "mmHg"}}
+        ]
+      }
+```
+
 ## Limitations
 
 - Assumes FHIR R4; older versions not addressed

--- a/docs/docs/skills/health-data-model-planning.md
+++ b/docs/docs/skills/health-data-model-planning.md
@@ -21,6 +21,34 @@ Plans health data entities, relationships, and governance choices before committ
 
 Produces `docs/planning/data-model-brief.md`.
 
+## Example
+
+```
+AI:   What does your app track or coordinate? And who creates,
+      reads, and updates that data?
+
+You:  Medication schedules, adherence logs, and vital signs.
+      Patients log adherence, nurses review it, doctors
+      adjust prescriptions.
+
+AI:   For each of those, here's a starting data model:
+
+      Medication Schedule
+      — Required: medication name, dose, frequency, start date
+      — Optional: end date, refill reminders, prescriber
+      — FHIR fit: MedicationRequest
+      — Lifecycle: draft → active → completed | cancelled
+
+      Adherence Log
+      — Required: medication ref, timestamp, taken (yes/no)
+      — Optional: reason skipped, notes
+      — FHIR fit: MedicationAdministration
+      — Lifecycle: recorded (immutable)
+
+      Should adherence data be shareable with external EHRs,
+      or is it self-contained within the app?
+```
+
 ## Limitations
 
 - Does not assume a specific database or framework

--- a/docs/docs/skills/keep-a-changelog-generator.md
+++ b/docs/docs/skills/keep-a-changelog-generator.md
@@ -13,6 +13,25 @@ Generates changelog entries from git history in the [Keep a Changelog](https://k
 3. Translates technical commit messages into user-facing language
 4. Flags breaking changes
 
+## Example Output
+
+```markdown
+## [1.2.0] - 2026-04-05
+
+### Added
+- Health data visualization screen with weekly and monthly trend views
+- Apple HealthKit integration for step count and heart rate
+- Export health data summary to PDF
+
+### Changed
+- Improved task scheduling performance for large medication lists
+- Updated questionnaire UI to support branching logic
+
+### Fixed
+- Fixed race condition in account state initialization (#45)
+- Resolved infinite loop when no scheduled tasks exist (#52)
+```
+
 ## Limitations
 
 - Quality depends on commit message quality — vague messages produce vague entries

--- a/docs/docs/skills/project-wiki.md
+++ b/docs/docs/skills/project-wiki.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 10
+---
+
+# project-wiki
+
+Set up and maintain a persistent, AI-managed knowledge base for a digital health project — turning clinical observations, papers, interviews, and planning docs into a compounding, interlinked wiki.
+
+## How It Works
+
+The wiki uses a three-layer architecture:
+
+- **Raw sources** (`wiki/raw/`) — Your immutable source documents: interview transcripts, papers, clinical observations, competitor research, regulatory docs. The AI reads from these but never modifies them.
+- **Wiki pages** (`wiki/pages/`) — AI-generated and AI-maintained markdown pages. Summaries, stakeholder maps, evidence tables, competitive landscapes, design rationale, and open questions — all interlinked and kept current.
+- **Schema** (`AGENTS.md` or `CLAUDE.md`) — Tells the AI how the wiki is structured and how to maintain it. You and the AI co-evolve this over time.
+
+When you add a source, the AI reads it, discusses key takeaways with you, and integrates it across the wiki — updating every relevant page, flagging contradictions, and logging the change. A single source may touch 5–15 wiki pages.
+
+### Three Workflows
+
+**Ingest** — Add a new source. Just say "Add this to my wiki" and share the content. The AI classifies it, saves it to the right folder, writes or updates wiki pages, and logs the change.
+
+**Query** — Ask a question. The AI searches the wiki, synthesizes an answer with citations, and offers to file useful answers back into the wiki so they compound.
+
+**Lint** — Health-check the wiki. The AI looks for contradictions, stale claims, orphan pages, missing cross-references, and evidence gaps.
+
+## Works With Other Skills
+
+If your project has planning documents from other SpeziVibe skills, the wiki seeds from them automatically — need statements become project overviews, UX briefs become user journey pages, compliance briefs become regulatory landscape pages.
+
+## Output
+
+Creates a `wiki/` directory with the full three-layer structure and a schema section in your project's `AGENTS.md` or `CLAUDE.md`.
+
+## Limitations
+
+- Designed for projects where knowledge accumulates over weeks or months — not for one-off questions
+- The AI maintains the wiki; it does not fabricate evidence or make clinical judgment calls
+- Not a replacement for formal literature reviews or regulatory submissions

--- a/docs/docs/skills/project-wiki.md
+++ b/docs/docs/skills/project-wiki.md
@@ -28,6 +28,32 @@ When you add a source, the AI reads it, discusses key takeaways with you, and in
 
 If your project has planning documents from other SpeziVibe skills, the wiki seeds from them automatically — need statements become project overviews, UX briefs become user journey pages, compliance briefs become regulatory landscape pages.
 
+## Example
+
+```
+You:  Add this to my wiki — [pastes patient interview transcript]
+
+AI:   I've saved it as wiki/raw/interviews/2026-04-05-patient-03-
+      cardiac-rehab.md.
+
+      Key takeaways:
+      — Patient stopped exercising after week 2 due to fatigue
+      — Caregiver wasn't aware of the exercise schedule
+      — Patient preferred text reminders over app notifications
+
+      This contradicts our earlier assumption that app-based
+      reminders are preferred — I've flagged that on the
+      evidence/adherence-barriers.md page.
+
+      Updated pages:
+      — stakeholders/patients.md (added fatigue as barrier)
+      — stakeholders/caregivers.md (new page — caregiver role)
+      — evidence/adherence-barriers.md (added contradiction flag)
+      — questions/open-questions.md (added: "Should we include
+        caregiver-facing features?")
+      — log.md (appended ingest entry)
+```
+
 ## Output
 
 Creates a `wiki/` directory with the full three-layer structure and a schema section in your project's `AGENTS.md` or `CLAUDE.md`.

--- a/docs/docs/skills/release-notes-generator.md
+++ b/docs/docs/skills/release-notes-generator.md
@@ -15,6 +15,34 @@ Creates user-facing release notes with feature highlights, fixes, breaking chang
 - Breaking Changes (with before/after code and migration steps)
 - Dependencies
 
+## Example Output
+
+```markdown
+# v1.2.0 Release Notes
+
+## Highlights
+This release adds health data visualization and improves task scheduling.
+Users can now view their health trends over time and export summaries.
+
+## New Features
+- **Health Data Charts** — View step count and heart rate trends
+  over the past week or month.
+- **PDF Export** — Share a health data summary with your care team.
+
+## Bug Fixes
+- Fixed account initialization race condition (#45)
+- Resolved infinite loop with empty task lists (#52)
+
+## Breaking Changes
+- `useHealthData()` now returns an object instead of an array.
+
+  // Before
+  const [data, isLoading] = useHealthData();
+
+  // After
+  const { data, isLoading } = useHealthData();
+```
+
 ## Limitations
 
 - Does not automatically extract breaking changes — requires manual identification

--- a/docs/docs/skills/spezi-platform-selection.md
+++ b/docs/docs/skills/spezi-platform-selection.md
@@ -22,6 +22,28 @@ Helps you choose between two template applications, sets up your development mac
 
 A cloned template repository with working navigation, theming, and project structure. All subsequent work happens inside the cloned repo.
 
+## Example
+
+```
+AI:   What kind of app are you building? Does it primarily involve
+      forms, questionnaires, and chat — or does it need HealthKit,
+      SensorKit, Bluetooth, or deep Apple integration?
+
+You:  It needs to read heart rate and step data from Apple Watch
+      and connect to a Bluetooth blood pressure cuff
+
+AI:   Those require HealthKit and CoreBluetooth, which are only
+      available natively on Apple platforms. I'd recommend the
+      Spezi Template Application.
+
+      Let me check your setup — do you have Xcode installed?
+
+You:  Yes, Xcode 16
+
+AI:   Great. I'll clone the Spezi Template Application to your
+      project directory and walk you through the structure.
+```
+
 ## Limitations
 
 - Machine setup must complete before cloning

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -22,6 +22,13 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Knowledge Management Skills',
+      items: [
+        'skills/project-wiki',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Release Skills',
       items: [
         'skills/keep-a-changelog-generator',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -442,6 +442,8 @@
   font-size: 0.82rem;
   color: var(--text-muted);
   margin-top: 0.5rem;
+  text-align: center;
+  width: 100%;
 }
 
 .alt-install a {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -438,6 +438,23 @@
   opacity: 1;
 }
 
+.alt-install {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin-top: 0.5rem;
+}
+
+.alt-install a {
+  color: var(--accent-light);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(232, 81, 26, 0.3);
+  transition: border-color 0.2s;
+}
+
+.alt-install a:hover {
+  border-color: var(--accent-light);
+}
+
 /* -- Scroll Indicator -- */
 .scroll-indicator {
   position: absolute;

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -232,7 +232,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 10rem 2rem 6rem;
+  padding: 7rem 2rem 6rem;
   min-height: 100vh;
   justify-content: center;
 }
@@ -426,6 +426,8 @@
   font-size: 0.78rem;
   font-family: 'JetBrains Mono', monospace;
   color: var(--text-muted);
+  margin: 0;
+  line-height: 1;
 }
 
 .install-hint .copied-msg {
@@ -438,31 +440,63 @@
   opacity: 1;
 }
 
-.alt-install {
-  font-size: 0.82rem;
+.install-or {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0;
+}
+
+.or-divider {
+  font-size: 0.8rem;
+  font-weight: 500;
   color: var(--text-muted);
-  margin-top: 0.5rem;
-  text-align: center;
-  width: 100%;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
 
-.alt-install a {
-  color: var(--accent-light);
+.btn-zip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(21, 21, 24, 0.4);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-subtle);
+  color: rgba(255,255,255,0.8);
+  padding: 0.7rem 1.6rem;
+  border-radius: 100px;
+  font-weight: 500;
+  font-size: 0.88rem;
   text-decoration: none;
-  border-bottom: 1px solid rgba(232, 81, 26, 0.3);
-  transition: border-color 0.2s;
+  cursor: pointer;
+  transition: all 0.3s;
 }
 
-.alt-install a:hover {
-  border-color: var(--accent-light);
+.btn-zip:hover {
+  color: #fff;
+  border-color: rgba(232, 81, 26, 0.4);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+[data-theme='light'] .btn-zip {
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+[data-theme='light'] .btn-zip:hover {
+  color: var(--text);
+  border-color: var(--accent);
 }
 
 /* -- Scroll Indicator -- */
 .scroll-indicator {
   position: absolute;
   bottom: 2.5rem;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -593,7 +627,7 @@
 .how-steps {
   margin-top: 3.5rem;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 1.5rem;
 }
 
@@ -614,7 +648,7 @@
   font-size: 0.9rem;
   font-weight: 700;
   color: var(--text);
-  margin-bottom: 1.25rem;
+  margin: 0 auto 1.25rem;
   position: relative;
   z-index: 2;
   transition: all 0.3s;
@@ -654,9 +688,9 @@
   position: absolute;
   top: 24px;
   left: calc(50% + 24px);
-  width: calc(100% - 48px);
+  right: calc(-50% - 24px - 1.5rem);
   height: 2px;
-  background: linear-gradient(90deg, var(--border) 0%, var(--border) 60%, transparent 100%);
+  background: var(--border);
   z-index: 1;
 }
 
@@ -1128,7 +1162,7 @@
   }
 
   .how-steps {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .skills-grid {

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -287,12 +287,13 @@ export default function Home() {
       <section className="landing-section" id="how">
         <div className="reveal">
           <p className="section-label">How it works</p>
-          <h2 className="section-title">Three steps. Zero boilerplate.</h2>
+          <h2 className="section-title">Four steps. From idea to app.</h2>
         </div>
         <div className="how-steps">
           <StepCard num="01" title="Install the skills" description="One command adds every skill to your AI coding tool. Works with any tool that supports installable skills or custom instructions." showConnector delayClass="reveal-delay-1" />
           <StepCard num="02" title="Describe your app" description="Tell your AI what you want to build. The build-an-app skill figures out which planning steps apply and walks you through each one interactively." showConnector delayClass="reveal-delay-2" />
-          <StepCard num="03" title="Get planning docs" description="Each skill produces a structured markdown document &mdash; need statements, compliance briefs, data models, UX briefs, and implementation plans." delayClass="reveal-delay-3" />
+          <StepCard num="03" title="Get planning docs" description="Each skill produces a structured markdown document &mdash; need statements, compliance briefs, data models, UX briefs, and implementation plans." showConnector delayClass="reveal-delay-3" />
+          <StepCard num="04" title="Build your app" description="Start from a Spezi template app and add pre-built modules for your use case. Your planning docs guide the AI as it wires everything together." delayClass="reveal-delay-4" />
         </div>
       </section>
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -247,13 +247,17 @@ export default function Home() {
         <h1>Vibe code<br /><span className="highlight">digital health</span></h1>
 
         <p className="subtitle">
-          Installable skills that help AI coding tools guide you through clinical, regulatory, and technical planning for digital health apps.
+          Installable skills that help AI coding tools plan, build, and ship digital health apps.
         </p>
 
         <InstallBlock />
-        <p className="alt-install">
-          or <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip">download as zip</a>
-        </p>
+        <div className="install-or" style={{animation: 'fade-in-up 0.8s ease-out 0.7s both'}}>
+          <span className="or-divider">or</span>
+          <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip" className="btn-zip">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+            Download as zip
+          </a>
+        </div>
 
         <div className="scroll-indicator">
           <span>Scroll to explore</span>
@@ -265,9 +269,9 @@ export default function Home() {
       <section className="landing-section what" id="about">
         <div className="reveal">
           <p className="section-label">What is SpeziVibe</p>
-          <h2 className="section-title">Guided planning for digital health apps</h2>
+          <h2 className="section-title">Plan and build digital health apps</h2>
           <p className="section-desc">
-            SpeziVibe is a collection of installable skills for AI coding tools. Each skill walks you through a specific planning area &mdash; needs analysis, compliance, data modeling, UX, study design &mdash; and produces a structured document you can build from.
+            SpeziVibe is a collection of installable skills for AI coding tools. Skills guide you from needs analysis and compliance through data modeling and UX &mdash; then help you build with Spezi templates, pre-built modules, and a living project knowledge base.
           </p>
           <p className="section-desc" style={{marginTop: '0.8rem'}}>
             From Stanford's Spezi initiative, built to lower the barrier to high-quality digital health experiences.
@@ -287,13 +291,13 @@ export default function Home() {
       <section className="landing-section" id="how">
         <div className="reveal">
           <p className="section-label">How it works</p>
-          <h2 className="section-title">Four steps. From idea to app.</h2>
+          <h2 className="section-title">From idea to app.</h2>
         </div>
         <div className="how-steps">
-          <StepCard num="01" title="Install the skills" description="One command adds every skill to your AI coding tool. Works with any tool that supports installable skills or custom instructions." showConnector delayClass="reveal-delay-1" />
-          <StepCard num="02" title="Describe your app" description="Tell your AI what you want to build. The build-an-app skill figures out which planning steps apply and walks you through each one interactively." showConnector delayClass="reveal-delay-2" />
-          <StepCard num="03" title="Get planning docs" description="Each skill produces a structured markdown document &mdash; need statements, compliance briefs, data models, UX briefs, and implementation plans." showConnector delayClass="reveal-delay-3" />
-          <StepCard num="04" title="Build your app" description="Start from a Spezi template app and add pre-built modules for your use case. Your planning docs guide the AI as it wires everything together." delayClass="reveal-delay-4" />
+          <StepCard num="01" title="Install" description="One command adds every skill to your AI coding tool. Works with anything that supports installable skills or custom instructions." showConnector delayClass="reveal-delay-1" />
+          <StepCard num="02" title="Plan" description="Describe what you want to build. Skills walk you through needs analysis, compliance, data modeling, UX, and study design &mdash; producing structured docs along the way." showConnector delayClass="reveal-delay-2" />
+          <StepCard num="03" title="Build" description="Start from a Spezi template app and add pre-built modules. Your planning docs guide the AI as it wires everything together." showConnector delayClass="reveal-delay-3" />
+          <StepCard num="04" title="Ship" description="Generate changelogs, release notes, and maintain a living project wiki that keeps your team's knowledge organized as you iterate." delayClass="reveal-delay-4" />
         </div>
       </section>
 
@@ -301,15 +305,15 @@ export default function Home() {
       <section className="landing-section skills-section" id="skills">
         <div className="reveal">
           <p className="section-label">Skills</p>
-          <h2 className="section-title">One skill per planning area</h2>
-          <p className="section-desc">Each skill covers a specific aspect of digital health planning and produces a structured output document.</p>
+          <h2 className="section-title">One skill per area</h2>
+          <p className="section-desc">Each skill covers a specific aspect of digital health development &mdash; from planning through building and maintenance.</p>
         </div>
         <div className="skills-grid">
           {/* Hero card */}
           <div className="glass-card skill-card skill-card-hero reveal">
             <div className="skill-icon">&#9734;</div>
             <h3>build-an-app</h3>
-            <p>Describe what you want to build. This skill figures out which planning steps apply, walks you through each one, and produces structured docs you can hand off to implementation.</p>
+            <p>Describe what you want to build. This skill figures out which steps apply, walks you through planning, and sets you up to build with the right template and modules.</p>
             <div className="skill-card-visual">
               <span className="cmt"># Example conversation</span><br /><br />
               <span className="str">&gt; I want to build a medication tracking app</span><br />
@@ -382,11 +386,15 @@ export default function Home() {
         <div className="cta-glow"></div>
         <div className="reveal">
           <h2>Get started</h2>
-          <p className="subtitle">One command. Every skill. Structured planning for digital health.</p>
+          <p className="subtitle">One command. Every skill. Plan, build, and ship digital health apps.</p>
           <InstallBlock />
-          <p className="alt-install">
-            or <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip">download as zip</a>
-          </p>
+          <div className="install-or">
+            <span className="or-divider">or</span>
+            <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip" className="btn-zip">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+              Download as zip
+            </a>
+          </div>
           <div className="action-buttons">
             <a href="https://github.com/StanfordSpezi/SpeziVibe" target="_blank" rel="noopener noreferrer" className="btn-primary">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -45,7 +45,7 @@ function InstallBlock() {
           </button>
         </div>
       </div>
-      <p className="install-hint">Click to copy &middot; <span className="copied-msg">Copied!</span></p>
+      <p className="install-hint"><span className="copied-msg">Copied!</span></p>
     </div>
   );
 }
@@ -251,6 +251,9 @@ export default function Home() {
         </p>
 
         <InstallBlock />
+        <p className="alt-install">
+          or <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip">download as zip</a>
+        </p>
 
         <div className="scroll-indicator">
           <span>Scroll to explore</span>
@@ -338,6 +341,8 @@ export default function Home() {
           <SkillCard icon="&#128200;" name="fhir-data-model-design" description="Maps clinical data types to specific FHIR R4 resources, terminology bindings, and relationships. Expert-driven recommendations with sample JSON. Produces a fhir-data-model.md." className="reveal-delay-1" />
           <SkillCard icon="&#128203;" name="app-build-planner" description="Reads the planning docs from other skills and produces a milestone-based implementation plan with tasks, dependencies, and verification criteria. Produces an implementation-plan.md." className="reveal-delay-2" />
 
+          <SkillCard icon="&#128214;" name="project-wiki" description="Set up a persistent, AI-maintained knowledge base for your project. Add interviews, papers, and clinical observations &mdash; the AI integrates them across interlinked wiki pages, flags contradictions, and keeps everything current." className="skill-card-wide" />
+
           <SkillCard icon="&#128196;" name="keep-a-changelog-generator" description="Generates changelog entries from git history in the Keep a Changelog format. Groups commits by category and translates technical messages into user-facing language." className="skill-card-wide" />
           <SkillCard icon="&#128172;" name="release-notes-generator" description="Creates user-facing release notes from git history with feature highlights, fixes, breaking changes, and migration guidance." className="skill-card-wide" />
         </div>
@@ -378,6 +383,9 @@ export default function Home() {
           <h2>Get started</h2>
           <p className="subtitle">One command. Every skill. Structured planning for digital health.</p>
           <InstallBlock />
+          <p className="alt-install">
+            or <a href="https://github.com/StanfordSpezi/SpeziVibe/releases/latest/download/spezivibe-skills.zip">download as zip</a>
+          </p>
           <div className="action-buttons">
             <a href="https://github.com/StanfordSpezi/SpeziVibe" target="_blank" rel="noopener noreferrer" className="btn-primary">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>


### PR DESCRIPTION
## Summary

- Add documentation page for the new `project-wiki` skill with a "Knowledge Management Skills" category in the sidebar and skills overview table
- Add a `project-wiki` card to the landing page skills grid
- Add "download as zip" link below install commands on the hero and bottom CTA sections for users who don't want to use `npx`
- Remove "Click to copy" text from install blocks
- Add a `build.yml` CI workflow (Docusaurus build + skill structure validation) and update the README badge from the deleted `static-analysis.yml`

## Test plan

- [x] Verify Docusaurus builds successfully (CI will run this)
- [x] Check the project-wiki doc page renders at `/docs/skills/project-wiki`
- [x] Confirm the skills overview table shows the new Knowledge Management Skills section
- [x] Confirm the sidebar shows the new category between Planning Skills and Release Skills
- [x] Verify the "download as zip" links point to the correct release URL
- [x] Verify the README build badge resolves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced project‑wiki skill for persistent, AI‑driven knowledge bases with ingest, query, and lint workflows.

* **Documentation**
  * Added comprehensive project‑wiki docs, examples for many skills, and a new sidebar entry describing structure, workflows, outputs, and limitations.

* **UI Updates**
  * Updated homepage to highlight project‑wiki, added a zip download CTA, simplified install hint text, adjusted hero/step layouts and styles.

* **Chores**
  * Added a CI build/validation workflow and updated the build status badge in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->