### PR TITLE
Clarify planning-first workflow and polish landing page

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 
 [submodule "react-native-template-app"]
 	path = react-native-template-app
-	url = https://github.com/CS342/ReactNativeTemplateApplication
+	url = https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,6 @@ skills/   Shared installable skills
 
 ## Entry Skill
 
-Use `skills/spezi-platform-selection` when the user needs help choosing the best starting platform for a new application.
+Use `skills/build-an-app` when a user wants to build a new digital health app or is unsure where to start. It orchestrates the other skills in the right order.
+
+Use `skills/spezi-platform-selection` directly when the user only needs help choosing between React Native and Apple-native.

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ npx skills add StanfordSpezi/SpeziVibe --skill '*' -a claude-code
 
 ## Where To Start
 
-The fastest way to get started is to run `build-an-app`. Describe what you want to build and it figures out which planning skills you need, runs them in order, and hands off to implementation. You do not need to know the individual skills or their order — the orchestrator handles that for you.
+The fastest way to get started is to run `build-an-app`. Describe what you want to build and it figures out which planning skills you need, runs them in order, and hands the implementation plan off to your AI coding agent for the actual build. You do not need to know the individual skills or their order — the orchestrator handles that for you.
 
-If you prefer to run skills individually, here is the process they follow. Not every project needs every skill — use what fits and skip what does not.
+If you prefer to run skills individually, here is the process they follow. Plan first; clone a Spezi template only when the plan is ready and you're set to build. Not every project needs every skill — use what fits.
 
 ### 1. Define the Need
 
@@ -105,13 +105,7 @@ Understand the clinical or operational problem before deciding on a product. Inv
 
 Use: `biodesign-needs-finding`
 
-### 2. Choose a Platform
-
-Decide whether the project is better suited to the React Native Template App or the Spezi Template Application for Apple Platforms, then clone the selected template.
-
-Use: `spezi-platform-selection`
-
-### 3. Plan the Product
+### 2. Plan the Product
 
 Design the user experience, data model, and compliance posture. Run whichever skills are relevant — not all are required for every project.
 
@@ -121,13 +115,25 @@ Design the user experience, data model, and compliance posture. Run whichever sk
 - `digital-health-compliance-planning` — privacy, regulatory, and governance expectations
 - `digital-health-study-planning` — study protocol, consent, and data collection (only if tied to a research study)
 
-### 4. Plan the Build
+Each skill writes a brief to `docs/planning/` in your working directory.
 
-Feed your planning outputs into `app-build-planner` to get a sequenced implementation plan. The output is a structured document (`docs/implementation-plan.md`) saved in your cloned template repository.
+### 3. Plan the Build
+
+Feed your planning outputs into `app-build-planner` to get a sequenced implementation plan. The output is `docs/implementation-plan.md` — milestones, tasks, dependencies, and verification criteria.
+
+Use: `app-build-planner`
+
+### 4. Choose a Platform and Clone the Template (optional)
+
+Once the plan is in hand, decide whether the project is better suited to React Native or Apple-native, then clone the matching Spezi starter template. This skill uses your planning briefs to inform the recommendation, clones the template, and moves your `docs/planning/` and `docs/implementation-plan.md` into the cloned repo.
+
+Use: `spezi-platform-selection`
+
+> **Skip this if you're not using a Spezi template.** The planning briefs and implementation plan work in any codebase — a blank Expo project, an existing repo, a different framework. Hand them to your coding agent directly and ask it to build Milestone 1.
 
 ### 5. Build the App
 
-Open the template repository you cloned in step 2 and work through `docs/implementation-plan.md` milestone by milestone with your coding agent. Build each one, verify it works, then move to the next.
+Ask your AI coding agent to implement Milestone 1 from `docs/implementation-plan.md`. The agent uses your planning briefs as context and the Spezi template's patterns as scaffolding (or your own codebase if you skipped step 4). Build each milestone, verify, then move to the next.
 
 ### 6. Keep Learning (Optional)
 
@@ -139,17 +145,19 @@ Use: `project-wiki`
 
 This repository is organized for `npx skills`, with one skill per folder under `skills/`.
 
+Listed in the order they typically run.
+
 | Skill | What it does |
 |-------|-------------|
 | `build-an-app` | Walk through the full process — from idea to running code |
-| `spezi-platform-selection` | Choose the right app foundation — React Native or Apple-native |
 | `biodesign-needs-finding` | Turn an idea into a real clinical need |
+| `digital-health-ux-planning` | Design a patient- and clinician-friendly experience |
 | `digital-health-study-planning` | Plan a study around the app |
 | `digital-health-compliance-planning` | Think through privacy and regulatory risk early |
 | `health-data-model-planning` | Shape the app's health data backbone |
-| `digital-health-ux-planning` | Design a patient- and clinician-friendly experience |
 | `fhir-data-model-design` | Map clinical concepts to FHIR |
 | `app-build-planner` | Turn planning outputs into a milestone-based build plan |
+| `spezi-platform-selection` | Choose React Native or Apple-native and clone the matching Spezi starter template (optional) |
 | `project-wiki` | Turn your project into a compounding, AI-maintained knowledge base |
 | `keep-a-changelog-generator` | Draft changelogs people can actually read |
 | `release-notes-generator` | Summarize a release clearly |
@@ -166,18 +174,6 @@ npx skills add StanfordSpezi/SpeziVibe --skill build-an-app
 
 </details>
 
-### `spezi-platform-selection`
-
-Choose the right app foundation — helps you decide whether a project is better served by the React Native Template App or the Spezi Template Application for Apple Platforms, then points the coding agent at the right next steps.
-
-<details><summary>Install</summary>
-
-```bash
-npx skills add StanfordSpezi/SpeziVibe --skill spezi-platform-selection
-```
-
-</details>
-
 ### `biodesign-needs-finding`
 
 Turn an idea into a real clinical need — guides a team through a Stanford Biodesign-style needs-finding process so they define the problem well before jumping to a solution.
@@ -186,6 +182,18 @@ Turn an idea into a real clinical need — guides a team through a Stanford Biod
 
 ```bash
 npx skills add StanfordSpezi/SpeziVibe --skill biodesign-needs-finding
+```
+
+</details>
+
+### `digital-health-ux-planning`
+
+Design a patient- and clinician-friendly experience — helps plan onboarding, core journeys, engagement loops, and day-to-day workflows for digital health products.
+
+<details><summary>Install</summary>
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill digital-health-ux-planning
 ```
 
 </details>
@@ -218,8 +226,6 @@ npx skills add StanfordSpezi/SpeziVibe --skill digital-health-compliance-plannin
 
 Shape the app's health data backbone — helps define core health concepts, entities, relationships, lifecycle states, and interoperability needs before implementation begins.
 
-If you are working inside the React Native Template App, the repo-local `data-model` skill carries the implementation-focused guidance for app entities, FHIR mappings, storage, and sync behavior.
-
 <details><summary>Install</summary>
 
 ```bash
@@ -228,23 +234,9 @@ npx skills add StanfordSpezi/SpeziVibe --skill health-data-model-planning
 
 </details>
 
-### `digital-health-ux-planning`
-
-Design a patient- and clinician-friendly experience — helps plan onboarding, core journeys, engagement loops, and day-to-day workflows for digital health products.
-
-<details><summary>Install</summary>
-
-```bash
-npx skills add StanfordSpezi/SpeziVibe --skill digital-health-ux-planning
-```
-
-</details>
-
 ### `fhir-data-model-design`
 
 Map clinical concepts to FHIR — translates clinical requirements into a FHIR R4-oriented data model with concrete resources, relationships, and implementation guidance.
-
-FHIR implementation review is now part of the React Native Template App's repo-local `fhir` skill, where it can stay aligned with the actual app mappings and services.
 
 <details><summary>Install</summary>
 
@@ -262,6 +254,18 @@ Turn planning outputs into a milestone-based build plan — extracts features fr
 
 ```bash
 npx skills add StanfordSpezi/SpeziVibe --skill app-build-planner
+```
+
+</details>
+
+### `spezi-platform-selection`
+
+Choose the right app foundation — helps you decide between **React Native** and **Apple-native** for a new app, clones the matching Spezi starter template, and moves your existing planning briefs into the cloned repo so the coding agent has full context.
+
+<details><summary>Install</summary>
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill spezi-platform-selection
 ```
 
 </details>

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -5,46 +5,89 @@ slug: /getting-started
 
 # Getting Started
 
-SpeziVibe is a collection of installable skills for AI coding tools. Each skill walks you through a specific digital health planning area — needs analysis, compliance, data modeling, UX, study design — and produces a structured markdown document you can build from.
+SpeziVibe is a collection of installable skills for AI coding tools. Each skill walks you through a specific digital health planning area and produces a structured markdown document you can build from.
 
-## Installation
+:::info The workflow
+SpeziVibe's planning skills produce structured markdown briefs. Your AI coding agent then uses those briefs (plus a Spezi template repo) to write the code. See [How SpeziVibe Works](/docs/how-it-works) for the full flow before you start.
+:::
 
-Install all skills with a single command:
+## Prerequisites
+
+You need **Node.js** (which includes `npm` and `npx`).
+
+1. Install a current Node.js release from [nodejs.org](https://nodejs.org/)
+2. Confirm the tools are available:
+
+```bash
+node -v
+npx -v
+```
+
+## Install All Skills
+
+Install every skill with one command:
 
 ```bash
 npx skills add StanfordSpezi/SpeziVibe --all
 ```
 
-Skills are tool-agnostic. They work with **Claude Code**, **Cursor**, **GitHub Copilot**, **OpenAI Codex**, **Gemini CLI**, and any other tool that supports installable skills or custom instructions.
+This installs into every detected coding tool. Skills work with **Claude Code**, **Cursor**, **GitHub Copilot**, **OpenAI Codex**, **Gemini CLI**, and any other tool that supports installable skills or custom instructions.
 
-## Quick Start
+## List Skills Before Installing
 
-Once installed, start by describing what you want to build. The **build-an-app** skill figures out which planning steps apply and walks you through each one interactively:
+See what's available without installing:
 
-1. **Describe your app** — Tell your AI coding tool what you want to build
-2. **Work through each skill** — Each relevant skill asks you questions and produces a planning document (e.g., `need-statement.md`, `compliance-brief.md`, `ux-brief.md`)
-3. **Get an implementation plan** — The app-build-planner reads your planning docs and produces a milestone-based build plan
+```bash
+npx skills add StanfordSpezi/SpeziVibe --list
+```
 
-## What's Included
+## Install a Single Skill
 
-SpeziVibe includes skills organized into planning and release categories:
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill build-an-app
+```
 
-### Planning Skills
-- **build-an-app** — Orchestrates the other skills based on what you describe; walks you through each one in order
-- **biodesign-needs-finding** — Guided needs-finding using the Stanford Biodesign process; produces `need-statement.md`
-- **spezi-platform-selection** — Helps choose between React Native and Apple-native, sets up your dev environment, and clones the starter repo
-- **digital-health-study-planning** — Plans a research protocol including enrollment, consent, assessments, and outcomes; produces `study-brief.md`
-- **digital-health-compliance-planning** — Walks through HIPAA, IRB, FDA, GDPR applicability and recommends controls; produces `compliance-brief.md` (not legal advice)
-- **health-data-model-planning** — Defines health data entities, relationships, and FHIR fit; produces `data-model-brief.md`
-- **digital-health-ux-planning** — Plans user journeys, onboarding, and engagement for patients and clinicians; produces `ux-brief.md`
-- **fhir-data-model-design** — Maps clinical data to FHIR R4 resources with terminology bindings and sample JSON; produces `fhir-data-model.md`
-- **app-build-planner** — Reads planning docs and produces a milestone-based implementation plan; produces `implementation-plan.md`
+Every skill's docs page includes a copy-paste install command. Start with [build-an-app](/docs/skills/build-an-app) if you're unsure where to begin.
 
-### Release Skills
-- **keep-a-changelog-generator** — Generates changelog entries from git history in Keep a Changelog format
-- **release-notes-generator** — Creates user-facing release notes with features, fixes, and migration guidance
+## Target a Specific Tool
+
+By default, the install targets every detected tool. To target a specific one, add `-a <agent>`:
+
+```bash
+# Claude Code only
+npx skills add StanfordSpezi/SpeziVibe --skill '*' -a claude-code
+
+# Codex only
+npx skills add StanfordSpezi/SpeziVibe --skill '*' -a codex
+```
+
+See the [`skills` tool](https://github.com/vercel-labs/skills) for the full list of supported agents.
+
+## Manual Install (No npx)
+
+If you prefer not to use `npx`:
+
+1. Download the latest `spezivibe-skills.zip` from [Releases](https://github.com/StanfordSpezi/SpeziVibe/releases)
+2. Unzip the archive
+3. Copy the skill folders into your tool's skills directory (e.g., `.claude/skills/` for Claude Code)
+
+## Verify the Install
+
+Open your AI coding tool and ask it to list the available skills:
+
+```
+List the SpeziVibe skills you have access to.
+```
+
+You should see `build-an-app`, `biodesign-needs-finding`, and the other skills in the catalog.
 
 ## Next Steps
 
-- Browse the [Skills reference](/docs/skills) for detailed descriptions of each skill
-- Visit the [GitHub repository](https://github.com/StanfordSpezi/SpeziVibe) for source code and contributions
+The fastest way to get started is to run `build-an-app`. Describe what you want to build and it figures out which planning skills apply, runs them in order, and hands off to implementation:
+
+```
+I want to build a medication tracking app for post-transplant
+patients. Use the build-an-app skill to walk me through it.
+```
+
+Browse the [Skills reference](/docs/skills) for what each skill does individually, or check the [GitHub repository](https://github.com/StanfordSpezi/SpeziVibe) for source code and contribution info.

--- a/docs/docs/how-it-works.md
+++ b/docs/docs/how-it-works.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 2
+slug: /how-it-works
+---
+
+# How SpeziVibe Works
+
+SpeziVibe is a set of installable **planning skills** that walk you through the decisions a digital health app needs — clinical need, compliance, data model, UX, study design — and produce a folder of structured markdown briefs.
+
+When the plan is ready, your AI coding agent reads those briefs and writes the code inside a Spezi template repo.
+
+## The Workflow
+
+1. **Plan first.** Open your AI coding tool in any working directory and run the planning skills. They ask you questions and write briefs into `docs/planning/`. Run only the ones that fit your project — `build-an-app` can orchestrate the right ones based on what you describe.
+2. **Sequence the build.** `app-build-planner` reads the briefs and produces `docs/implementation-plan.md` — a milestone-by-milestone build plan.
+3. **Choose a platform and clone the template.** `spezi-platform-selection` picks **React Native** or **Apple-native** based on what your planning revealed, clones the matching Spezi template, and brings your planning docs along so they're inside the cloned repo.
+4. **Build, one milestone at a time.** Inside the cloned template, tell your coding agent: *"Implement Milestone 1 from `docs/implementation-plan.md`."* It uses your planning briefs as context and the template's existing patterns as scaffolding to write the code.
+5. **Ship.** Generate changelogs and release notes. Maintain a `project-wiki` of accumulated knowledge as the project grows.
+
+## Mental Model
+
+> The planning skills produce the **brief**. Your coding agent produces the **code**.
+
+The briefs are the bridge — clear, structured decisions an agent can ground itself in instead of guessing. The Spezi template gives the agent battle-tested architecture, modules, and patterns to build on top of.
+
+You don't clone the template until you're ready to build. Planning is platform-agnostic on purpose — a need statement, compliance brief, or FHIR data model shouldn't change based on whether you eventually pick React Native or Apple-native.
+
+## Where Files Live
+
+Before cloning, briefs live in your working directory:
+
+```
+my-planning/
+└─ docs/
+   ├─ planning/
+   │  ├─ need-statement.md
+   │  ├─ compliance-brief.md
+   │  ├─ ux-brief.md
+   │  ├─ data-model-brief.md
+   │  ├─ fhir-data-model.md
+   │  └─ study-brief.md
+   └─ implementation-plan.md
+```
+
+After `spezi-platform-selection` clones the template and brings planning along, your project looks like:
+
+```
+my-app/                  ← cloned Spezi template
+├─ docs/
+│  ├─ planning/          ← moved in from your planning directory
+│  └─ implementation-plan.md
+├─ src/                  ← your agent writes code here
+└─ ...                   ← template scaffolding
+```
+
+Commit `docs/planning/` and `docs/implementation-plan.md` to source control. The agent — and future contributors — will keep coming back to them.
+
+## Building Without a Spezi Template
+
+The Spezi templates are recommended scaffolding, not a requirement. The planning briefs and implementation plan are platform-agnostic markdown — your AI coding agent can build from them in any project:
+
+- A blank Expo / React Native project
+- A blank Xcode / SwiftUI project
+- An existing repo you already have
+- A different framework entirely (Flutter, Kotlin, web, etc.)
+
+To skip the template path:
+
+1. Run the planning skills in any working directory.
+2. Skip `spezi-platform-selection`, or run it just for the platform recommendation and clone manually into a project of your choice.
+3. Open your project in your AI coding tool.
+4. Tell the agent: *"Read `docs/planning/` and `docs/implementation-plan.md`. Implement Milestone 1 in this codebase."*
+
+Your agent uses the briefs as context and writes code in whatever stack you're working in. You give up the Spezi-specific scaffolding — pre-wired onboarding/consent flows, HealthKit integration, FHIR mappings, design tokens — and your agent will rebuild those from scratch (or skip them). The trade is more flexibility for more work.
+
+**When this makes sense:**
+
+- You're extending an existing app
+- Your stack is outside React Native or Apple-native
+- You want full control over architecture decisions
+- You're prototyping and don't need production-grade scaffolding yet
+
+When in doubt, use a template. It's the faster path to a working app.
+
+## Why Stop at Markdown?
+
+The planning skills deliberately don't generate code. A milestone in `implementation-plan.md` might say:
+
+> *Build a medication list view that reads from Firestore, follows the design tokens in the Spezi template, and handles offline cache.*
+
+That's specific enough for a modern AI coding agent to execute, and flexible enough that it can adapt to your team's conventions, evolving requirements, and new Spezi modules as they ship.
+
+Code generators get stale. A precise plan + a smart agent + a maintained template stays current.

--- a/docs/docs/skills.md
+++ b/docs/docs/skills.md
@@ -5,21 +5,25 @@ slug: /skills
 
 # Skills Overview
 
-Each skill covers a specific area of digital health development &mdash; from planning through building and maintenance. Use them individually or let **build-an-app** orchestrate them based on what you describe.
+SpeziVibe's skills produce platform-agnostic markdown briefs that your AI coding agent uses to write the code. See [How SpeziVibe Works](/docs/how-it-works) for the full flow.
+
+Use these individually, or let **build-an-app** orchestrate them based on what you describe.
 
 ## Planning Skills
 
+Listed in the order they typically run. `build-an-app` orchestrates them; `spezi-platform-selection` is optional and runs last (only if you want a Spezi template).
+
 | Skill | What it does | Output |
 |-------|-------------|--------|
-| [build-an-app](skills/build-an-app) | Orchestrates other skills based on your description | Runs relevant skills in sequence |
-| [biodesign-needs-finding](skills/biodesign-needs-finding) | Guided needs-finding using Stanford Biodesign process | `need-statement.md` |
-| [spezi-platform-selection](skills/spezi-platform-selection) | Choose platform, set up environment, clone starter repo | Cloned template repo |
-| [digital-health-study-planning](skills/digital-health-study-planning) | Plan a research protocol (enrollment, consent, assessments) | `study-brief.md` |
-| [digital-health-compliance-planning](skills/digital-health-compliance-planning) | Identify applicable compliance domains and controls (not legal advice) | `compliance-brief.md` |
-| [health-data-model-planning](skills/health-data-model-planning) | Define health data entities, relationships, and FHIR fit | `data-model-brief.md` |
-| [digital-health-ux-planning](skills/digital-health-ux-planning) | Plan user journeys and workflows (no wireframes) | `ux-brief.md` |
-| [fhir-data-model-design](skills/fhir-data-model-design) | Map clinical data to FHIR R4 resources and terminology | `fhir-data-model.md` |
-| [app-build-planner](skills/app-build-planner) | Produce milestone-based implementation plan from planning docs | `implementation-plan.md` |
+| [build-an-app](skills/build-an-app) | Orchestrates the other skills based on your description | Runs relevant skills in sequence |
+| [biodesign-needs-finding](skills/biodesign-needs-finding) | Guided needs-finding using the Stanford Biodesign process | `docs/planning/need-statement.md` |
+| [digital-health-ux-planning](skills/digital-health-ux-planning) | Plan user journeys and workflows (no wireframes) | `docs/planning/ux-brief.md` |
+| [digital-health-study-planning](skills/digital-health-study-planning) | Plan a research protocol (enrollment, consent, assessments) | `docs/planning/study-brief.md` |
+| [digital-health-compliance-planning](skills/digital-health-compliance-planning) | Identify applicable compliance domains and controls (not legal advice) | `docs/planning/compliance-brief.md` |
+| [health-data-model-planning](skills/health-data-model-planning) | Define health data entities, relationships, and FHIR fit | `docs/planning/data-model-brief.md` |
+| [fhir-data-model-design](skills/fhir-data-model-design) | Map clinical data to FHIR R4 resources and terminology | `docs/planning/fhir-data-model.md` |
+| [app-build-planner](skills/app-build-planner) | Produce a milestone-based implementation plan from the planning briefs | `docs/implementation-plan.md` |
+| [spezi-platform-selection](skills/spezi-platform-selection) | Choose React Native or Apple-native, clone the matching Spezi template, move planning briefs into it | Cloned template repo with planning briefs inside |
 
 ## Knowledge Management Skills
 

--- a/docs/docs/skills/app-build-planner.md
+++ b/docs/docs/skills/app-build-planner.md
@@ -1,10 +1,20 @@
 ---
-sidebar_position: 9
+sidebar_position: 8
 ---
 
 # app-build-planner
 
-Reads planning documents from the other skills and produces a milestone-based implementation plan. Does not generate code.
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill app-build-planner
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
+Reads planning documents from the other skills and produces a milestone-based implementation plan. Does not generate code — your AI coding agent uses the plan to write the code. See [How SpeziVibe Works](/docs/how-it-works).
 
 ## Inputs
 
@@ -17,7 +27,7 @@ Reads whichever of these exist (works with whatever's available):
 - `docs/planning/fhir-data-model.md`
 - `docs/planning/compliance-brief.md`
 
-Also needs your platform choice (React Native or Apple-native) and backend choice (Firebase, Medplum, or other).
+Also needs your platform choice (React Native, Apple-native, or another framework you're using) and backend choice (Firebase, Medplum, or other). If you're not using a Spezi template, the plan still works — see [How SpeziVibe Works](/docs/how-it-works#building-without-a-spezi-template).
 
 ## Output
 
@@ -34,11 +44,11 @@ Produces `docs/implementation-plan.md` containing:
 ## Example
 
 ```
-AI:   Which template did you clone — React Native or Spezi
-      Template Application? And which backend — Firebase,
-      Medplum, or something else?
+AI:   Which platform are you on — React Native, Apple-native, or
+      something else? And which backend — Firebase, Medplum, or
+      something else?
 
-You:  Spezi Template Application with Firebase.
+You:  Apple-native with Firebase.
 
 AI:   I've read your planning docs. Here's a proposed milestone
       sequence:
@@ -72,3 +82,7 @@ AI:   I've read your planning docs. Here's a proposed milestone
 - Features without matching packages are flagged as "custom implementation" with effort estimates
 - Milestones are capped at 5-7 tasks; larger ones are split
 - Flags all gaps from missing planning inputs
+
+## Next Step
+
+Open `docs/implementation-plan.md` in your AI coding tool and ask the agent to build Milestone 1. Each milestone has a goal, tasks, and verification criteria — structured so the agent can execute sequentially. Build, verify, commit, repeat.

--- a/docs/docs/skills/biodesign-needs-finding.md
+++ b/docs/docs/skills/biodesign-needs-finding.md
@@ -4,6 +4,16 @@ sidebar_position: 2
 
 # biodesign-needs-finding
 
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill biodesign-needs-finding
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
 Walks you through a Stanford Biodesign-style needs-finding process to define a clear, solution-free problem statement.
 
 ## How It Works

--- a/docs/docs/skills/build-an-app.md
+++ b/docs/docs/skills/build-an-app.md
@@ -4,7 +4,17 @@ sidebar_position: 1
 
 # build-an-app
 
-The main entry point for SpeziVibe. Describe what you want to build and this skill determines which planning skills apply, then walks you through each one in sequence.
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill build-an-app
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
+The main entry point for SpeziVibe. Describe what you want to build and this skill determines which planning skills apply, walks you through each one in sequence, and produces an implementation plan your AI coding agent can build from. See [How SpeziVibe Works](/docs/how-it-works).
 
 ## How It Works
 
@@ -34,12 +44,18 @@ Skills are skipped if you already have the corresponding planning document.
 ```
 You:  I want to build a medication tracking app for post-transplant patients
 
-AI:   Based on your description, I'd recommend these planning steps:
+AI:   Based on your description, here's the sequence I'd recommend:
       1. biodesign-needs-finding — define the core problem
       2. digital-health-compliance-planning — HIPAA and medication data
       3. health-data-model-planning — medication schedules, adherence
       4. digital-health-ux-planning — patient and caregiver workflows
       5. app-build-planner — implementation plan with milestones
+      6. spezi-platform-selection — pick React Native or Apple-native,
+         clone the matching template (when you're ready to build)
+
+      All planning briefs land in docs/planning/. spezi-platform-selection
+      runs last and brings them into the cloned template, where your
+      coding agent will start building.
 
       Want to proceed with this order?
 
@@ -52,3 +68,11 @@ AI:   Starting with needs-finding. What specific problem are
 ## Output
 
 Each skill produces its own document in `docs/planning/`. The final output is an `implementation-plan.md` with milestones, tasks, and dependencies.
+
+## What Happens Next
+
+After `build-an-app` finishes, you have a folder of planning briefs and `docs/implementation-plan.md`. Inside your cloned Spezi template, tell your AI coding agent:
+
+> *Implement Milestone 1 from `docs/implementation-plan.md`.*
+
+The agent uses your planning briefs as context and the Spezi template's patterns as scaffolding to write the code. See [How SpeziVibe Works](/docs/how-it-works) for the full flow.

--- a/docs/docs/skills/digital-health-compliance-planning.md
+++ b/docs/docs/skills/digital-health-compliance-planning.md
@@ -4,6 +4,16 @@ sidebar_position: 5
 
 # digital-health-compliance-planning
 
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill digital-health-compliance-planning
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
 Helps you reason through which compliance domains apply to your project and what controls you should consider. Framework-agnostic — recommends capabilities, not specific implementations.
 
 ## Domains Assessed

--- a/docs/docs/skills/digital-health-study-planning.md
+++ b/docs/docs/skills/digital-health-study-planning.md
@@ -4,6 +4,16 @@ sidebar_position: 4
 
 # digital-health-study-planning
 
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill digital-health-study-planning
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
 Helps plan a digital health research protocol. Platform-agnostic — focuses on the study design, not the app stack.
 
 ## What It Covers

--- a/docs/docs/skills/digital-health-ux-planning.md
+++ b/docs/docs/skills/digital-health-ux-planning.md
@@ -1,8 +1,18 @@
 ---
-sidebar_position: 7
+sidebar_position: 3
 ---
 
 # digital-health-ux-planning
+
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill digital-health-ux-planning
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
 
 Plans user experience journeys for digital health products. Platform-agnostic — focuses on user goals and decision points, not specific screens.
 

--- a/docs/docs/skills/fhir-data-model-design.md
+++ b/docs/docs/skills/fhir-data-model-design.md
@@ -1,8 +1,18 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 # fhir-data-model-design
+
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill fhir-data-model-design
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
 
 Maps clinical data types to specific FHIR R4 resources, terminology bindings, and relationships. Unlike most other skills, this one is expert-driven — it provides recommendations rather than asking Socratic questions.
 

--- a/docs/docs/skills/health-data-model-planning.md
+++ b/docs/docs/skills/health-data-model-planning.md
@@ -4,6 +4,16 @@ sidebar_position: 6
 
 # health-data-model-planning
 
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill health-data-model-planning
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
 Plans health data entities, relationships, and governance choices before committing to a storage layer. Biased toward FHIR for clinically meaningful or shareable data, but allows opt-out with justification.
 
 ## What It Covers

--- a/docs/docs/skills/keep-a-changelog-generator.md
+++ b/docs/docs/skills/keep-a-changelog-generator.md
@@ -1,8 +1,18 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # keep-a-changelog-generator
+
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill keep-a-changelog-generator
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
 
 Generates changelog entries from git history in the [Keep a Changelog](https://keepachangelog.com) format.
 

--- a/docs/docs/skills/project-wiki.md
+++ b/docs/docs/skills/project-wiki.md
@@ -4,6 +4,16 @@ sidebar_position: 10
 
 # project-wiki
 
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill project-wiki
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
 Set up and maintain a persistent, AI-managed knowledge base for a digital health project — turning clinical observations, papers, interviews, and planning docs into a compounding, interlinked wiki.
 
 ## How It Works

--- a/docs/docs/skills/release-notes-generator.md
+++ b/docs/docs/skills/release-notes-generator.md
@@ -1,8 +1,18 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # release-notes-generator
+
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill release-notes-generator
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
 
 Creates user-facing release notes with feature highlights, fixes, breaking changes, and migration guidance.
 

--- a/docs/docs/skills/spezi-platform-selection.md
+++ b/docs/docs/skills/spezi-platform-selection.md
@@ -1,26 +1,39 @@
 ---
-sidebar_position: 3
+sidebar_position: 9
 ---
 
 # spezi-platform-selection
 
-Helps you choose between two template applications, sets up your development machine, and clones the appropriate starter repo.
+:::tip Install this skill
+
+```bash
+npx skills add StanfordSpezi/SpeziVibe --skill spezi-platform-selection
+```
+
+Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [Getting Started guide](/docs/getting-started) for tool-specific options.
+
+:::
+
+Runs **after** the other planning skills finish, when the user is ready to build with a Spezi template. Uses the planning briefs to recommend a platform, clones the matching Spezi starter template, and moves the existing `docs/planning/` and `docs/implementation-plan.md` into the cloned repo so the coding agent has full context.
+
+Skip this skill if you're not using a Spezi template — your planning briefs and implementation plan work just as well in any codebase. See [Building Without a Spezi Template](/docs/how-it-works#building-without-a-spezi-template).
 
 ## Platform Options
 
-- **React Native Template App** — Cross-platform (iOS, Android). Good for forms, questionnaires, chat, and lightweight integrations.
-- **Spezi Template Application for Apple Platforms** — iPhone, iPad, Vision Pro. For apps requiring HealthKit, SensorKit, Bluetooth, or deep Apple integration.
+- **React Native** — cross-platform (iOS + Android) from one codebase. Good for forms, questionnaires, chat, and lightweight integrations. Backed by the Spezi React Native Template App.
+- **Apple-native** — Swift / SwiftUI for iPhone, iPad, and Vision Pro. Use when HealthKit, SensorKit, Bluetooth, or deep Apple integration is core to the product. Backed by the Spezi Template Application for Apple Platforms.
 
 ## How It Works
 
-1. Evaluates your requirements and constraints
-2. Recommends a template with reasoning
+1. Reads the planning briefs to understand requirements
+2. Recommends React Native or Apple-native with reasoning grounded in the briefs
 3. Checks your development machine setup (Xcode, Node.js, etc.)
-4. Clones the chosen template to a location you specify
+4. Clones the matching Spezi starter template to a location you specify
+5. Moves your planning briefs and implementation plan into the cloned repo
 
 ## Output
 
-A cloned template repository with working navigation, theming, and project structure. All subsequent work happens inside the cloned repo.
+A cloned template repository with working navigation, theming, and project structure, plus your `docs/planning/` and `docs/implementation-plan.md` already inside it. From here, your AI coding agent reads the plan and starts building.
 
 ## Example
 
@@ -32,16 +45,15 @@ AI:   What kind of app are you building? Does it primarily involve
 You:  It needs to read heart rate and step data from Apple Watch
       and connect to a Bluetooth blood pressure cuff
 
-AI:   Those require HealthKit and CoreBluetooth, which are only
-      available natively on Apple platforms. I'd recommend the
-      Spezi Template Application.
+AI:   Those require HealthKit and CoreBluetooth, which work best
+      natively on Apple platforms. I'd recommend going Apple-native.
 
       Let me check your setup — do you have Xcode installed?
 
 You:  Yes, Xcode 16
 
-AI:   Great. I'll clone the Spezi Template Application to your
-      project directory and walk you through the structure.
+AI:   Great. I'll clone the Spezi iOS template into your project
+      directory and walk you through the structure.
 ```
 
 ## Limitations

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -4,6 +4,7 @@
 const sidebars = {
   docsSidebar: [
     'getting-started',
+    'how-it-works',
     'skills',
     {
       type: 'category',
@@ -11,25 +12,25 @@ const sidebars = {
       items: [
         'skills/build-an-app',
         'skills/biodesign-needs-finding',
-        'skills/spezi-platform-selection',
+        'skills/digital-health-ux-planning',
         'skills/digital-health-study-planning',
         'skills/digital-health-compliance-planning',
         'skills/health-data-model-planning',
-        'skills/digital-health-ux-planning',
         'skills/fhir-data-model-design',
         'skills/app-build-planner',
+        'skills/spezi-platform-selection',
       ],
     },
     {
       type: 'category',
-      label: 'Knowledge Management Skills',
+      label: 'Knowledge Management',
       items: [
         'skills/project-wiki',
       ],
     },
     {
       type: 'category',
-      label: 'Release Skills',
+      label: 'Release',
       items: [
         'skills/keep-a-changelog-generator',
         'skills/release-notes-generator',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1,4 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800;900&family=Inter:wght@300;400;500;600;700;800;900&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+@property --ring-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
 
 :root {
   --ifm-color-primary: #d04917;
@@ -145,9 +151,9 @@
   100% { transform: translate(40px, -40px); }
 }
 
-@keyframes rocket-hover {
-  0%, 100% { transform: translateY(0); filter: drop-shadow(0 0 20px rgba(232,81,26,0.3)); }
-  50% { transform: translateY(-12px); filter: drop-shadow(0 20px 40px rgba(232,81,26,0.6)); }
+@keyframes rocket-glow {
+  0%, 100% { transform: rotate(45deg) scale(1);    filter: drop-shadow(0 0 20px rgba(232,81,26,0.3)); }
+  50%      { transform: rotate(45deg) scale(1.03); filter: drop-shadow(0 0 40px rgba(232,81,26,0.6)); }
 }
 
 @keyframes pulse-ring {
@@ -232,7 +238,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 7rem 2rem 6rem;
+  padding: 6rem 2rem 9rem;
   min-height: 100vh;
   justify-content: center;
 }
@@ -276,12 +282,13 @@
   position: relative;
   margin-bottom: 2rem;
   animation: fade-in-up 0.8s ease-out 0.15s both;
+  overflow: visible;
 }
 
 .hero-rocket {
   width: 120px;
   height: 120px;
-  animation: rocket-hover 3s ease-in-out infinite;
+  animation: rocket-glow 3.5s ease-in-out infinite;
 }
 
 .rocket-glow-ring {
@@ -298,20 +305,26 @@
 }
 
 .landing-hero h1 {
-  font-size: clamp(3rem, 8vw, 5.5rem);
-  font-weight: 900;
-  letter-spacing: -0.05em;
-  line-height: 0.95;
-  max-width: 750px;
+  font-family: 'Geist', 'Inter', sans-serif;
+  font-size: clamp(3.25rem, 8.5vw, 6rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+  max-width: 900px;
   animation: fade-in-up 0.8s ease-out 0.3s both;
-  background: linear-gradient(to bottom right, #fff, rgba(255,255,255,0.9), rgba(255,255,255,0.4));
+  background: linear-gradient(to bottom right, #fff, rgba(255,255,255,0.92), rgba(255,255,255,0.5));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  padding-bottom: 0.1em;
+  padding-bottom: 0.12em;
 }
 
 .landing-hero h1 .highlight {
+  font-family: 'Instrument Serif', 'Iowan Old Style', Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  font-variation-settings: normal;
   background: linear-gradient(135deg, var(--accent) 0%, var(--accent-light) 50%, var(--accent-warm) 100%);
   background-size: 200% 200%;
   animation: gradient-shift 4s ease infinite;
@@ -343,21 +356,49 @@
 .install-cmd-wrapper {
   position: relative;
   width: 100%;
-  max-width: 520px;
+  max-width: 540px;
+}
+
+.install-cmd-wrapper::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 15.5px;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--ring-angle),
+    transparent 0%,
+    transparent 55%,
+    var(--accent) 75%,
+    var(--accent-light) 82%,
+    var(--accent-warm) 88%,
+    transparent 100%
+  );
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: ring-rotate 6s linear infinite;
+  pointer-events: none;
+  opacity: 0.85;
 }
 
 .install-cmd-wrapper .glow-bg {
   position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, rgba(232,81,26,0.15), transparent);
-  opacity: 0;
+  inset: -12px;
+  background: radial-gradient(ellipse at center, rgba(232,81,26,0.22), transparent 65%);
+  opacity: 0.5;
   transition: opacity 0.5s;
-  border-radius: 14px;
-  filter: blur(8px);
+  border-radius: 24px;
+  filter: blur(18px);
+  pointer-events: none;
 }
 
 .install-cmd-wrapper:hover .glow-bg {
   opacity: 1;
+}
+
+@keyframes ring-rotate {
+  to { --ring-angle: 360deg; }
 }
 
 .install-cmd {
@@ -494,7 +535,7 @@
 /* -- Scroll Indicator -- */
 .scroll-indicator {
   position: absolute;
-  bottom: 2.5rem;
+  bottom: 1.75rem;
   left: 0;
   right: 0;
   display: flex;
@@ -539,10 +580,11 @@
 }
 
 .section-title {
-  font-size: clamp(2rem, 5vw, 3rem);
-  font-weight: 800;
-  letter-spacing: -0.04em;
-  line-height: 1.1;
+  font-family: 'Geist', 'Inter', sans-serif;
+  font-size: clamp(2.1rem, 5vw, 3.1rem);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
   max-width: 600px;
   color: var(--text);
 }
@@ -694,7 +736,7 @@
   z-index: 1;
 }
 
-/* -- Skills Bento Grid -- */
+/* -- Skills Section -- */
 .skills-section {
   text-align: center;
 }
@@ -705,6 +747,133 @@
   margin-right: auto;
 }
 
+.skill-featured-wrapper {
+  margin: 3.5rem auto 0;
+  max-width: 940px;
+  text-align: left;
+}
+
+.phase-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+}
+
+.phase-eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(232,81,26,0.6);
+}
+
+.skill-featured {
+  padding: 2.25rem;
+}
+
+.skill-phase {
+  margin: 4rem auto 0;
+  max-width: 1120px;
+  text-align: left;
+}
+
+.skill-phase-header {
+  margin-bottom: 1.5rem;
+}
+
+.skill-phase-header .phase-num {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+
+.skill-phase-header .phase-desc {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  font-weight: 300;
+  max-width: 620px;
+  margin: 0;
+}
+
+.skill-phase-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.skill-card-emphasis {
+  background: rgba(232, 81, 26, 0.05) !important;
+  border-color: rgba(232, 81, 26, 0.18) !important;
+}
+
+a.skill-card-link,
+.skill-featured-head {
+  color: inherit;
+  text-decoration: none;
+  position: relative;
+  display: block;
+}
+
+a.skill-card-link:hover,
+a.skill-card-link:focus-visible,
+.skill-featured-head:hover,
+.skill-featured-head:focus-visible {
+  color: inherit;
+  text-decoration: none;
+}
+
+a.skill-card-link:focus-visible,
+.skill-featured-head:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 16px;
+}
+
+.skill-card-arrow {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  color: var(--accent);
+  font-size: 1.1rem;
+  line-height: 1;
+  opacity: 0;
+  transform: translateX(-6px);
+  transition: opacity 0.3s, transform 0.3s;
+  pointer-events: none;
+}
+
+a.skill-card-link:hover .skill-card-arrow,
+.skill-featured-head:hover .skill-card-arrow {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+@media (max-width: 1024px) {
+  .skill-phase-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .skill-phase-grid {
+    grid-template-columns: 1fr;
+  }
+  .skill-phase {
+    margin-top: 3rem;
+  }
+}
+
+/* legacy bento — kept harmless in case anything else references them */
 .skills-grid {
   margin-top: 3rem;
   display: grid;
@@ -766,29 +935,55 @@
   grid-column: span 4;
 }
 
-.skill-card-hero .skill-card-visual {
+.skill-card-visual {
   margin-top: 1.5rem;
-  background: rgba(0,0,0,0.4);
+  background: rgba(0,0,0,0.55);
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 1rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.72rem;
+  padding: 1.1rem 1.25rem;
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 0.78rem;
   color: var(--text-muted);
-  line-height: 1.8;
+  line-height: 1.85;
   overflow: hidden;
+  position: relative;
 }
 
-.skill-card-hero .skill-card-visual .kw {
-  color: #c084fc;
+.skill-card-visual::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 28px;
+  background: rgba(255,255,255,0.02);
+  border-bottom: 1px solid var(--border-subtle);
+  pointer-events: none;
 }
 
-.skill-card-hero .skill-card-visual .str {
+.skill-card-visual::after {
+  content: '● ● ●';
+  position: absolute;
+  top: 8px;
+  left: 12px;
+  font-size: 0.5rem;
+  letter-spacing: 0.3em;
+  color: rgba(255,255,255,0.18);
+  pointer-events: none;
+}
+
+.skill-card-visual > *:first-child {
+  margin-top: 1.25rem;
+  display: inline-block;
+}
+
+.skill-card-visual .str {
   color: var(--accent-light);
 }
 
-.skill-card-hero .skill-card-visual .cmt {
-  color: rgba(255,255,255,0.25);
+.skill-card-visual .cmt {
+  color: rgba(255,255,255,0.32);
+  font-style: italic;
 }
 
 .live-badge {
@@ -901,10 +1096,11 @@
 }
 
 .bottom-cta h2 {
-  font-size: clamp(2.5rem, 6vw, 4rem);
-  font-weight: 900;
+  font-family: 'Geist', 'Inter', sans-serif;
+  font-size: clamp(2.6rem, 6vw, 4rem);
+  font-weight: 700;
   letter-spacing: -0.04em;
-  line-height: 1.05;
+  line-height: 1.04;
   position: relative;
   color: var(--text);
 }
@@ -937,23 +1133,40 @@
   gap: 0.5rem;
   background: #fff;
   color: #000;
-  padding: 0.85rem 2rem;
+  padding: 0.95rem 2.2rem;
   border-radius: 100px;
   font-weight: 600;
   font-size: 0.95rem;
   text-decoration: none;
   border: none;
   cursor: pointer;
-  transition: all 0.3s;
+  transition: transform 0.3s, box-shadow 0.3s;
   box-shadow: 0 0 40px rgba(255,255,255,0.08);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.btn-primary::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 35%, rgba(232,81,26,0.28) 50%, transparent 65%);
+  transform: translateX(-100%);
+  transition: transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+  pointer-events: none;
 }
 
 .btn-primary:hover {
-  background: #e8e8ed;
-  transform: translateY(-1px);
-  box-shadow: 0 0 60px rgba(255,255,255,0.12);
+  background: #fff;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(232,81,26,0.25), 0 0 60px rgba(255,255,255,0.12);
   color: #000;
   text-decoration: none;
+}
+
+.btn-primary:hover::after {
+  transform: translateX(100%);
 }
 
 .btn-secondary {
@@ -1054,22 +1267,23 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.08);
 }
 
-[data-theme='light'] .skill-card-hero .skill-card-visual {
-  background: rgba(0,0,0,0.04);
-  border-color: var(--border);
-  color: var(--text-muted);
+[data-theme='light'] .skill-card-visual {
+  background: rgba(15,15,18,0.96);
+  border-color: rgba(255,255,255,0.08);
+  color: rgba(255,255,255,0.55);
 }
 
-[data-theme='light'] .skill-card-hero .skill-card-visual .kw {
-  color: #7c3aed;
+[data-theme='light'] .skill-card-visual::before {
+  background: rgba(255,255,255,0.04);
+  border-bottom-color: rgba(255,255,255,0.08);
 }
 
-[data-theme='light'] .skill-card-hero .skill-card-visual .str {
-  color: var(--accent);
+[data-theme='light'] .skill-card-visual .str {
+  color: var(--accent-light);
 }
 
-[data-theme='light'] .skill-card-hero .skill-card-visual .cmt {
-  color: rgba(0,0,0,0.3);
+[data-theme='light'] .skill-card-visual .cmt {
+  color: rgba(255,255,255,0.32);
 }
 
 [data-theme='light'] .compat {

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -73,17 +73,22 @@ function StepCard({num, title, description, showConnector, delayClass}) {
   );
 }
 
-function SkillCard({icon, name, description, className, children}) {
+function SkillCard({icon, name, description, className, children, href}) {
+  const linkHref = href || `/docs/skills/${name}`;
+  if (children) {
+    return (
+      <div className={`glass-card skill-card ${className || ''} reveal`}>
+        {children}
+      </div>
+    );
+  }
   return (
-    <div className={`glass-card skill-card ${className || ''} reveal`}>
-      {children || (
-        <>
-          <div className="skill-icon">{icon}</div>
-          <h3>{name}</h3>
-          <p>{description}</p>
-        </>
-      )}
-    </div>
+    <a href={linkHref} className={`glass-card skill-card skill-card-link ${className || ''} reveal`}>
+      <div className="skill-icon">{icon}</div>
+      <h3>{name}</h3>
+      <p>{description}</p>
+      <span className="skill-card-arrow" aria-hidden="true">&rarr;</span>
+    </a>
   );
 }
 
@@ -271,17 +276,17 @@ export default function Home() {
           <p className="section-label">What is SpeziVibe</p>
           <h2 className="section-title">Plan and build digital health apps</h2>
           <p className="section-desc">
-            SpeziVibe is a collection of installable skills for AI coding tools. Skills guide you from needs analysis and compliance through data modeling and UX &mdash; then help you build with Spezi templates, pre-built modules, and a living project knowledge base.
+            SpeziVibe&rsquo;s installable skills turn an idea into structured markdown briefs — needs, compliance, data model, UX, study design — and an implementation plan your AI coding agent can build from.
           </p>
           <p className="section-desc" style={{marginTop: '0.8rem'}}>
-            From Stanford's Spezi initiative, built to lower the barrier to high-quality digital health experiences.
+            When the plan is ready, <code>spezi-platform-selection</code> clones a matching Spezi template (React Native or Apple-native) so the agent has battle-tested architecture and modules to build on. <a href="/docs/how-it-works">How it works &rarr;</a>
           </p>
         </div>
         <div className="what-visual">
           <SkillPill icon="&#9734;" name="build-an-app" desc="Idea to running code" delayClass="reveal-delay-1" />
-          <SkillPill icon="&#9881;" name="spezi-platform-selection" desc="React Native or native" delayClass="reveal-delay-1" />
+          <SkillPill icon="&#9881;" name="spezi-platform-selection" desc="React Native or Apple-native" delayClass="reveal-delay-1" />
           <SkillPill icon="&#9829;" name="biodesign-needs-finding" desc="Stanford Biodesign" delayClass="reveal-delay-2" />
-          <SkillPill icon="&#128203;" name="digital-health-compliance" desc="Compliance planning" delayClass="reveal-delay-2" />
+          <SkillPill icon="&#128203;" name="digital-health-compliance-planning" desc="Compliance planning" delayClass="reveal-delay-2" />
           <SkillPill icon="&#128200;" name="fhir-data-model-design" desc="FHIR R4 mapping" delayClass="reveal-delay-3" />
           <SkillPill icon="&#128241;" name="digital-health-ux-planning" desc="UX journeys" delayClass="reveal-delay-3" />
         </div>
@@ -294,9 +299,9 @@ export default function Home() {
           <h2 className="section-title">From idea to app.</h2>
         </div>
         <div className="how-steps">
-          <StepCard num="01" title="Install" description="One command adds every skill to your AI coding tool. Works with anything that supports installable skills or custom instructions." showConnector delayClass="reveal-delay-1" />
-          <StepCard num="02" title="Plan" description="Describe what you want to build. Skills walk you through needs analysis, compliance, data modeling, UX, and study design &mdash; producing structured docs along the way." showConnector delayClass="reveal-delay-2" />
-          <StepCard num="03" title="Build" description="Start from a Spezi template app and add pre-built modules. Your planning docs guide the AI as it wires everything together." showConnector delayClass="reveal-delay-3" />
+          <StepCard num="01" title="Install" description="One command adds every planning skill to your AI coding tool. Works with anything that supports installable skills or custom instructions." showConnector delayClass="reveal-delay-1" />
+          <StepCard num="02" title="Plan" description="In any working directory, describe what you want to build. Skills walk you through needs analysis, compliance, data modeling, UX, and study design &mdash; producing structured markdown briefs and an implementation plan." showConnector delayClass="reveal-delay-2" />
+          <StepCard num="03" title="Build" description="When the plan is ready, clone a Spezi template (React Native or Apple-native) &mdash; or skip the template and use any codebase. Your AI coding agent reads the briefs and writes the code, milestone by milestone." showConnector delayClass="reveal-delay-3" />
           <StepCard num="04" title="Ship" description="Generate changelogs, release notes, and maintain a living project wiki that keeps your team's knowledge organized as you iterate." delayClass="reveal-delay-4" />
         </div>
       </section>
@@ -306,14 +311,22 @@ export default function Home() {
         <div className="reveal">
           <p className="section-label">Skills</p>
           <h2 className="section-title">One skill per area</h2>
-          <p className="section-desc">Each skill covers a specific aspect of digital health development &mdash; from planning through building and maintenance.</p>
+          <p className="section-desc">Each skill covers a specific aspect of digital health development. Grouped by where they fit in your project lifecycle.</p>
         </div>
-        <div className="skills-grid">
-          {/* Hero card */}
-          <div className="glass-card skill-card skill-card-hero reveal">
-            <div className="skill-icon">&#9734;</div>
-            <h3>build-an-app</h3>
-            <p>Describe what you want to build. This skill figures out which steps apply, walks you through planning, and sets you up to build with the right template and modules.</p>
+
+        {/* Featured orchestrator */}
+        <div className="skill-featured-wrapper reveal">
+          <div className="phase-eyebrow">
+            <span className="phase-eyebrow-dot"></span>
+            Start here
+          </div>
+          <div className="glass-card skill-card skill-featured">
+            <a href="/docs/skills/build-an-app" className="skill-featured-head">
+              <div className="skill-icon">&#9734;</div>
+              <h3>build-an-app</h3>
+              <p>Describe what you want to build. This skill figures out which steps apply, walks you through planning, and sets you up to build with the right template and modules.</p>
+              <span className="skill-card-arrow" aria-hidden="true">&rarr;</span>
+            </a>
             <div className="skill-card-visual">
               <span className="cmt"># Example conversation</span><br /><br />
               <span className="str">&gt; I want to build a medication tracking app</span><br />
@@ -326,30 +339,55 @@ export default function Home() {
               &nbsp;&nbsp;app-build-planner
             </div>
           </div>
+        </div>
 
-          <SkillCard icon="&#9881;" name="spezi-platform-selection" description="Choose between the React Native Template App and the Spezi Template Application for Apple Platforms, set up your dev environment, and clone the right starter repo." className="reveal-delay-1" />
-          <SkillCard icon="&#9829;" name="biodesign-needs-finding" description="Walks you through a Stanford Biodesign-style needs-finding process to define a clear problem statement before jumping to solutions. Produces a need-statement.md." className="reveal-delay-2" />
-
-          <SkillCard icon="&#128218;" name="digital-health-study-planning" description="Helps plan a research protocol &mdash; enrollment, consent, data collection, assessment schedules, and outcome measures. Produces a study-brief.md." className="skill-card-wide" />
-
-          <div className="glass-card skill-card skill-card-wide reveal" style={{background: 'rgba(232, 81, 26, 0.04)', borderColor: 'rgba(232, 81, 26, 0.12)'}}>
-            <div className="live-badge">
-              <div className="dot"></div>
-              <span>Critical Path</span>
-            </div>
-            <h3>digital-health-compliance-planning</h3>
-            <p>Helps you reason through HIPAA, IRB, FDA, GDPR, and related compliance questions early. Produces a compliance-brief.md with identified domains and recommended controls. Not legal advice.</p>
+        {/* Phase 01: Plan */}
+        <div className="skill-phase reveal">
+          <div className="skill-phase-header">
+            <span className="phase-num">01 &middot; Plan</span>
+            <p className="phase-desc">Define the problem and design the system before writing code.</p>
           </div>
+          <div className="skill-phase-grid">
+            <SkillCard icon="&#9829;" name="biodesign-needs-finding" description="Walks you through a Stanford Biodesign-style needs-finding process to define a clear problem statement. Produces a need-statement.md." />
+            <a href="/docs/skills/digital-health-compliance-planning" className="glass-card skill-card skill-card-link skill-card-emphasis reveal">
+              <div className="live-badge">
+                <div className="dot"></div>
+                <span>Critical Path</span>
+              </div>
+              <h3>digital-health-compliance-planning</h3>
+              <p>Reason through HIPAA, IRB, FDA, GDPR, and related compliance questions early. Produces a compliance-brief.md. Not legal advice.</p>
+              <span className="skill-card-arrow" aria-hidden="true">&rarr;</span>
+            </a>
+            <SkillCard icon="&#128218;" name="digital-health-study-planning" description="Plan a research protocol &mdash; enrollment, consent, data collection, assessment schedules, and outcome measures. Produces a study-brief.md." />
+            <SkillCard icon="&#128241;" name="digital-health-ux-planning" description="Plan user journeys, onboarding, engagement, and day-to-day workflows for patients and clinicians. Produces a ux-brief.md." />
+            <SkillCard icon="&#128202;" name="health-data-model-planning" description="Define health data entities, relationships, lifecycle states, and interoperability needs. Produces a data-model-brief.md." />
+            <SkillCard icon="&#128200;" name="fhir-data-model-design" description="Map clinical data types to specific FHIR R4 resources, terminology bindings, and relationships. Produces a fhir-data-model.md." />
+          </div>
+        </div>
 
-          <SkillCard icon="&#128202;" name="health-data-model-planning" description="Helps define health data entities, relationships, lifecycle states, and interoperability needs. Biased toward FHIR for clinically meaningful data. Produces a data-model-brief.md." className="reveal-delay-1" />
-          <SkillCard icon="&#128241;" name="digital-health-ux-planning" description="Plans user journeys, onboarding, engagement, and day-to-day workflows for patients and clinicians. Platform-agnostic &mdash; no wireframes, just goals and decision points. Produces a ux-brief.md." className="reveal-delay-2" />
-          <SkillCard icon="&#128200;" name="fhir-data-model-design" description="Maps clinical data types to specific FHIR R4 resources, terminology bindings, and relationships. Expert-driven recommendations with sample JSON. Produces a fhir-data-model.md." className="reveal-delay-1" />
-          <SkillCard icon="&#128203;" name="app-build-planner" description="Reads the planning docs from other skills and produces a milestone-based implementation plan with tasks, dependencies, and verification criteria. Produces an implementation-plan.md." className="reveal-delay-2" />
+        {/* Phase 02: Build */}
+        <div className="skill-phase reveal">
+          <div className="skill-phase-header">
+            <span className="phase-num">02 &middot; Build</span>
+            <p className="phase-desc">Choose your platform and turn planning docs into an implementation plan.</p>
+          </div>
+          <div className="skill-phase-grid">
+            <SkillCard icon="&#9881;" name="spezi-platform-selection" description="Choose between React Native and Apple-native for your app, set up your dev environment, and clone the matching Spezi starter template." />
+            <SkillCard icon="&#128203;" name="app-build-planner" description="Reads the planning docs from other skills and produces a milestone-based implementation plan with tasks, dependencies, and verification criteria. Produces an implementation-plan.md." />
+          </div>
+        </div>
 
-          <SkillCard icon="&#128214;" name="project-wiki" description="Set up a persistent, AI-maintained knowledge base for your project. Add interviews, papers, and clinical observations &mdash; the AI integrates them across interlinked wiki pages, flags contradictions, and keeps everything current." className="skill-card-wide" />
-
-          <SkillCard icon="&#128196;" name="keep-a-changelog-generator" description="Generates changelog entries from git history in the Keep a Changelog format. Groups commits by category and translates technical messages into user-facing language." className="skill-card-wide" />
-          <SkillCard icon="&#128172;" name="release-notes-generator" description="Creates user-facing release notes from git history with feature highlights, fixes, breaking changes, and migration guidance." className="skill-card-wide" />
+        {/* Phase 03: Ship */}
+        <div className="skill-phase reveal">
+          <div className="skill-phase-header">
+            <span className="phase-num">03 &middot; Ship &amp; maintain</span>
+            <p className="phase-desc">Release with confidence and keep your team&rsquo;s knowledge organized as you iterate.</p>
+          </div>
+          <div className="skill-phase-grid">
+            <SkillCard icon="&#128214;" name="project-wiki" description="A persistent, AI-maintained knowledge base for your project. Add interviews, papers, and clinical observations &mdash; the AI integrates them across interlinked pages." />
+            <SkillCard icon="&#128196;" name="keep-a-changelog-generator" description="Generates changelog entries from git history in the Keep a Changelog format. Groups commits by category and translates messages into user-facing language." />
+            <SkillCard icon="&#128172;" name="release-notes-generator" description="Creates user-facing release notes from git history with feature highlights, fixes, breaking changes, and migration guidance." />
+          </div>
         </div>
       </section>
 

--- a/skills/app-build-planner/SKILL.md
+++ b/skills/app-build-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-build-planner
-description: Turn planning outputs into a milestone-based implementation plan that sequences features, maps them to available packages or modules, and hands off to a repo-local build skill.
+description: Turn planning outputs into a milestone-based implementation plan that sequences features, maps them to available packages or modules, and hands off to a coding agent for implementation.
 ---
 
 <!--
@@ -20,8 +20,9 @@ The primary deliverable is a structured **implementation plan document** saved i
 Use this skill when:
 
 - you have completed one or more planning skills (UX planning, data model planning, compliance planning, etc.)
-- you have already run `spezi-platform-selection` and cloned a template repository
-- you are ready to move from planning into implementation but want a clear sequence of what to build first
+- you are ready to turn that planning into a milestone-based build sequence
+
+Run this after the other planning skills and **before** `spezi-platform-selection`. The platform choice can be informed by what the plan reveals (HealthKit needs, cross-platform requirements, etc.).
 
 Do not use this skill if you have not done any planning work yet. Start with the planning skills first.
 
@@ -38,7 +39,7 @@ You are a directive implementation planner. You synthesize planning outputs and 
 5. Sequence features into ordered milestones
 6. Produce the implementation plan document
 
-**All output is in chat.** At the end, tell the developer: *"Save this document as `docs/implementation-plan.md` in your project. Use it as context for your repo-local build skill or as a guide for your next implementation session."*
+**All output is in chat.** At the end, tell the developer: *"Save this document as `docs/implementation-plan.md` in your project. Your coding agent will use it as the sequenced build plan — milestone by milestone."*
 
 ---
 
@@ -71,13 +72,14 @@ Identify the choices made during platform selection.
 
 Ask:
 
-1. "Which template did you clone — the React Native Template App or the Spezi Template Application for Apple Platforms?"
+1. "Which platform are you on — React Native, Apple-native, or something else (e.g. Flutter, web, an existing repo)?"
 2. "Which backend are you using — Firebase, Medplum, or something else?"
 
 Read the appropriate reference file based on the platform:
 
 - React Native → read [react-native-packages.md](references/react-native-packages.md)
 - Apple-native → read [apple-native-modules.md](references/apple-native-modules.md)
+- Other platforms → skip the Spezi package/module mapping; produce a generic plan the agent can implement using whatever framework conventions apply
 
 ---
 
@@ -186,7 +188,7 @@ Generate the full implementation plan document using this format:
 |-------|-------|
 | App | [Name and one-line description] |
 | Need statement | [From biodesign-needs-finding, or "Not available"] |
-| Platform | [React Native / Apple-native] |
+| Platform | [React Native / Apple-native / Other — specify] |
 | Backend | [Firebase / Medplum / Other] |
 | Study context | [Yes — brief description / No] |
 
@@ -259,8 +261,8 @@ Save this document as `docs/implementation-plan.md` in your project repository.
 
 To start building, work through the milestones one at a time with your coding
 agent. Each milestone is designed to be built and reviewed as a single focused
-session. If your cloned repository has a local build skill, use that. Otherwise,
-share this document as context and ask your agent to implement the first milestone.
+session. Share this document with your agent as context and ask it to implement
+Milestone 1 — verify, commit, then move to the next.
 ```
 
 ---
@@ -271,7 +273,7 @@ share this document as context and ask your agent to implement the first milesto
 - **Do not assume a backend** unless the user has confirmed their choice. Ask.
 - **Do not skip missing inputs.** If a planning area was not completed, note it as a gap and flag what the user might want to revisit.
 - **Keep milestones small and testable.** Each milestone should produce a visible, verifiable change. If a milestone has more than 5-7 tasks, consider splitting it.
-- **Stay platform-aware but not platform-expert.** Reference the correct packages and modules from the reference files but leave detailed implementation guidance to the repo-local build skill.
+- **Stay platform-aware but not platform-expert.** Reference the correct packages and modules from the reference files; leave detailed code-level implementation to the coding agent that will build from this plan.
 - **Respect priority.** Must-have features go into early milestones. Nice-to-have features go at the end and can be dropped without breaking the plan.
 
 ---

--- a/skills/app-build-planner/references/apple-native-modules.md
+++ b/skills/app-build-planner/references/apple-native-modules.md
@@ -4,9 +4,9 @@ SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CO
 SPDX-License-Identifier: MIT
 -->
 
-# Apple-Native Modules
+# Apple-native Modules
 
-Spezi Swift modules available in the Spezi Template Application for Apple Platforms. Added via Swift Package Manager.
+Spezi Swift modules available in the Apple-native starter template ([Spezi Template Application for Apple Platforms](https://github.com/StanfordSpezi/SpeziTemplateApplication)). Added via Swift Package Manager.
 
 ## SpeziAccount
 

--- a/skills/build-an-app/SKILL.md
+++ b/skills/build-an-app/SKILL.md
@@ -67,7 +67,7 @@ Based on what you heard, assemble a plan from the available skills. Every skill 
 | Skill | Include when |
 |-------|-------------|
 | `biodesign-needs-finding` | User is unsure about the problem, has a vague idea, or asks for help scoping |
-| `spezi-platform-selection` | User does not already have a project repo — helps choose React Native or Apple-native and clones the template |
+| `spezi-platform-selection` | User does not already have a project repo — runs last to choose React Native or Apple-native, clone the matching template, and move the planning briefs into it |
 | `digital-health-ux-planning` | User does not already have designs or wireframes |
 | `health-data-model-planning` | App stores or processes health data (vitals, assessments, patient records) |
 | `fhir-data-model-design` | App needs FHIR interoperability or connects to EHRs |
@@ -98,20 +98,22 @@ Work through the selected skills in the order below. For each one:
 
 ### Execution order and output paths
 
+All planning skills run **before** `spezi-platform-selection`, so the user is not committed to a platform until the plan is in hand.
+
 Run skills in this order (skipping any that were not selected):
 
 | Skill | Output Path | What it Produces |
 |-------|-------------|-----------------|
 | `biodesign-needs-finding` | `docs/planning/need-statement.md` | Need statement: problem, population, outcome |
-| `spezi-platform-selection` | Cloned template repository | Working project directory with template code |
 | `digital-health-ux-planning` | `docs/planning/ux-brief.md` | User journeys, onboarding, workflows |
 | `digital-health-study-planning` | `docs/planning/study-brief.md` | Study protocol, enrollment, assessments |
 | `health-data-model-planning` | `docs/planning/data-model-brief.md` | Entities, relationships, FHIR recommendations |
 | `fhir-data-model-design` | `docs/planning/fhir-data-model.md` | FHIR resources, terminology, relationships |
 | `digital-health-compliance-planning` | `docs/planning/compliance-brief.md` | Privacy domains, controls, required decisions |
 | `app-build-planner` | `docs/implementation-plan.md` | Milestone-based build sequence |
+| `spezi-platform-selection` | Cloned template repository | Working project directory with template code; planning briefs moved into the cloned repo |
 
-After running `spezi-platform-selection`, all subsequent outputs are saved inside the cloned template repository.
+`spezi-platform-selection` runs last (when the user is ready to build). It uses the planning briefs to recommend a platform, clones the matching Spezi template, and moves the existing `docs/planning/` and `docs/implementation-plan.md` into the cloned repo so the coding agent has full context.
 
 Between each skill, ask: "Ready to move on, or do you want to adjust anything?"
 

--- a/skills/spezi-platform-selection/SKILL.md
+++ b/skills/spezi-platform-selection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spezi-platform-selection
-description: Ask about an app's requirements, explain the tradeoff between the React Native Template App and the Spezi Template Application for Apple Platforms, clone the right repository, and hand off to the cloned project's local skills and instructions.
+description: Choose between React Native and Apple-native for a digital health app, clone the matching Spezi starter template, and move existing planning briefs into the cloned repo so the coding agent has full context for implementation.
 ---
 
 <!--
@@ -11,16 +11,20 @@ SPDX-License-Identifier: MIT
 
 # Spezi Platform Selection
 
-Use this skill when a user needs help choosing the right starter application and bootstrapping a new project.
+Use this skill when a user has finished planning, wants to start from a Spezi template, and is ready to build. It chooses between **React Native** and **Apple-native** based on the planning briefs, clones the matching Spezi starter template, and moves the existing `docs/planning/` and `docs/implementation-plan.md` into the cloned repo so the coding agent has full context.
 
-## Candidate Templates
+This skill should run **after** the other planning skills, not before — the platform choice is informed by what the planning revealed (HealthKit needs, cross-platform requirements, etc.).
+
+## When Not To Use
+
+Skip this skill if the user is not adopting a Spezi template — for example, they're extending an existing app, using a different framework (Flutter, web, etc.), or want full control over scaffolding. The planning briefs and implementation plan work just as well in any codebase; the user can hand them to their coding agent directly.
+
+## Platform Options
 
 Read [setup-guide.md](references/setup-guide.md) before making the recommendation.
 
-- **React Native Template App**
-- **Spezi Template Application for Apple Platforms**
-
-The Apple Platforms template supports iPhone, iPad, and Vision Pro.
+- **React Native** — cross-platform (iOS + Android) from one codebase. Backed by the Spezi React Native Template App.
+- **Apple-native** — Swift / SwiftUI for iPhone, iPad, and Vision Pro. Backed by the Spezi Template Application for Apple Platforms.
 
 ## Ask First
 
@@ -32,7 +36,7 @@ Ask concise questions that reveal whether the app is primarily:
 Confirm:
 
 1. who the users are
-2. whether cross-platform support matters at launch
+2. whether Android support matters at launch
 3. whether the app is iPhone-only or Apple-platform focused
 4. whether native Apple capabilities are core to product value
 
@@ -40,12 +44,12 @@ Confirm:
 
 Read [platform-decision.md](references/platform-decision.md) before deciding.
 
-Choose the **React Native Template App** when:
+Choose **React Native** when:
 
-- cross-platform delivery matters
+- cross-platform delivery (iOS + Android) matters
 - the product is primarily content, questionnaires, scheduling, chat, or lightweight integrations
 
-Choose the **Spezi Template Application for Apple Platforms** when:
+Choose **Apple-native** when:
 
 - HealthKit, SensorKit, Bluetooth, or another Apple-native SDK is product-critical
 - the app is explicitly for iPhone, iPad, or Vision Pro
@@ -55,8 +59,8 @@ Choose the **Spezi Template Application for Apple Platforms** when:
 
 After deciding on a platform, guide the user through the matching setup steps in [setup-guide.md](references/setup-guide.md) before cloning and implementation.
 
-- For the **Spezi Template Application for Apple Platforms**, prefer helping the user install and validate Xcode first.
-- For the **React Native Template App**, help the user set up a proper Expo and React Native development environment for the targets they care about.
+- For **Apple-native**, prefer helping the user install and validate Xcode first.
+- For **React Native**, help the user set up a proper Expo and React Native development environment for the targets they care about.
 
 Make sure the user is clear whether they want:
 
@@ -68,21 +72,32 @@ Make sure the user is clear whether they want:
 
 Use the bundled clone helper instead of writing ad hoc clone commands:
 
-- `scripts/clone-template.sh rn-cs342-template <destination>`
-- `scripts/clone-template.sh spezi-template <destination>`
+- React Native: `scripts/clone-template.sh react-native <destination>`
+- Apple-native: `scripts/clone-template.sh apple-native <destination>`
 
-After cloning:
+## Carry Planning Forward
+
+If the current working directory contains a `docs/planning/` directory or a `docs/implementation-plan.md` produced by the other planning skills, **move them into the cloned repository** so the coding agent picks up the full plan from the right place:
+
+```bash
+mv docs/planning <destination>/docs/planning
+mv docs/implementation-plan.md <destination>/docs/implementation-plan.md
+```
+
+Confirm with the user before moving. If the cloned repo already contains a `docs/planning/` directory, merge rather than overwrite.
+
+After the move:
 
 1. inspect the cloned repository's local instructions
-2. inspect the cloned repository's `skills/` directory if present
-3. continue implementation inside the cloned repository rather than in this root repo
+2. continue implementation inside the cloned repository rather than in the original planning directory
 
 ## Output
 
 End with a short summary containing:
 
-- chosen template
-- why it was selected
+- chosen platform (React Native or Apple-native)
+- why it was selected (cite the planning briefs that drove the decision)
 - machine setup steps completed or still required
 - clone destination
-- the next local skills or instructions to inspect in the cloned repository
+- whether planning briefs were moved into the cloned repo
+- next step: ask the coding agent to implement Milestone 1 from `docs/implementation-plan.md`

--- a/skills/spezi-platform-selection/references/platform-decision.md
+++ b/skills/spezi-platform-selection/references/platform-decision.md
@@ -6,13 +6,19 @@ SPDX-License-Identifier: MIT
 
 # Platform Decision Guide
 
-Use the **React Native Template App** when:
+Choose between **React Native** and **Apple-native** based on the product's defining requirements.
 
-- cross-platform support matters from the beginning
+## React Native
+
+Use the Spezi React Native Template App when:
+
+- cross-platform support (iOS + Android) matters from the beginning
 - the app is mostly content, education, forms, questionnaires, scheduling, or chat
 - native integrations are shallow or optional
 
-Use the **Spezi Template Application for Apple Platforms** when:
+## Apple-native
+
+Use the Spezi Template Application for Apple Platforms when:
 
 - HealthKit is a core system of record
 - SensorKit is required
@@ -20,4 +26,6 @@ Use the **Spezi Template Application for Apple Platforms** when:
 - background collection or deep Apple-native behavior is required
 - the target experience is explicitly for iPhone, iPad, or Vision Pro
 
-If the request wants both strong cross-platform support and strong Apple-native capabilities, explain the tradeoff clearly and bias toward the platform that best serves the product-defining requirement.
+## When Both Matter
+
+If the request wants both strong cross-platform support and strong Apple-native capabilities, explain the tradeoff clearly and bias toward the platform that best serves the product-defining requirement. Cross-platform reach and deep native integration are real tradeoffs — pick the one the product cannot do without.

--- a/skills/spezi-platform-selection/references/setup-guide.md
+++ b/skills/spezi-platform-selection/references/setup-guide.md
@@ -6,7 +6,10 @@ SPDX-License-Identifier: MIT
 
 # Setup Guide
 
-The setup workflow routes developers to one of two template applications.
+The setup workflow routes developers to one of two starter templates:
+
+- **React Native** → Spezi React Native Template App
+- **Apple-native** → Spezi Template Application for Apple Platforms
 
 Before cloning a template, help the user get their machine into a usable development state for the platform they chose.
 
@@ -23,9 +26,9 @@ Then have them:
 2. install Node.js so `npm` and `npx` are available
 3. confirm `node -v`, `npm -v`, and `npx -v` work
 
-## Apple Platform Setup
+## Apple-native Setup
 
-Use this setup when the user chooses the **Spezi Template Application for Apple Platforms**.
+Use this setup when the user chooses **Apple-native**.
 
 ### Install Xcode
 
@@ -45,18 +48,28 @@ If the user wants to run apps on a physical Apple device, remind them they may a
 - an Apple Developer account
 - code signing configured in Xcode
 
-Only after Xcode is installed and working should the workflow proceed to cloning the Apple template.
+Only after Xcode is installed and working should the workflow proceed to cloning the Apple-native template.
 
-## React Native Template App
+### Template
 
-- Clone key: `rn-cs342-template`
-- Repository: [CS342/ReactNativeTemplateApplication](https://github.com/CS342/ReactNativeTemplateApplication)
+- Clone key: `apple-native`
+- Repository: [StanfordSpezi/SpeziTemplateApplication](https://github.com/StanfordSpezi/SpeziTemplateApplication)
 
-Use this template when cross-platform delivery matters and the product is not defined by deep Apple-native integration.
+The template targets:
+
+- iPhone
+- iPad
+- Vision Pro
+
+Use it when Apple-native capabilities such as HealthKit, SensorKit, Bluetooth, or deep platform behavior are central to the app.
+
+## React Native Setup
+
+Use this setup when the user chooses **React Native**.
 
 ### Set Up A React Native Development Environment
 
-For the React Native Template App, guide the user toward a proper [Expo environment setup](https://docs.expo.dev/get-started/set-up-your-environment/) rather than a one-off quickstart.
+Guide the user toward a proper [Expo environment setup](https://docs.expo.dev/get-started/set-up-your-environment/) rather than a one-off quickstart.
 
 Make sure the user has:
 
@@ -78,17 +91,7 @@ Explain the tradeoff clearly:
 
 Before cloning the React Native template, confirm the user can support the targets they care about on their machine.
 
-## Spezi Template Application for Apple Platforms
+### Template
 
-- Clone key: `spezi-template`
-- Repository: [StanfordSpezi/SpeziTemplateApplication](https://github.com/StanfordSpezi/SpeziTemplateApplication)
-
-This template targets:
-
-- iPhone
-- iPad
-- Vision Pro
-
-Use it when Apple-native capabilities such as HealthKit, SensorKit, Bluetooth, or deep platform behavior are central to the app.
-
-After the user has a working Xcode installation, proceed with the Apple template clone and handoff.
+- Clone key: `react-native`
+- Repository: [StanfordSpezi/SpeziVibeReactNativeTemplate](https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate)

--- a/skills/spezi-platform-selection/scripts/clone-template.sh
+++ b/skills/spezi-platform-selection/scripts/clone-template.sh
@@ -10,8 +10,8 @@
 set -eu
 
 if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <project-name> <destination>" >&2
-  echo "Projects: rn-cs342-template | spezi-template" >&2
+  echo "Usage: $0 <platform> <destination>" >&2
+  echo "Platforms: react-native | apple-native" >&2
   exit 1
 fi
 
@@ -19,15 +19,15 @@ PROJECT_NAME="$1"
 DESTINATION="$2"
 
 case "$PROJECT_NAME" in
-  rn-cs342-template)
-    REMOTE_URL="https://github.com/CS342/ReactNativeTemplateApplication"
+  react-native)
+    REMOTE_URL="https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate"
     ;;
-  spezi-template)
+  apple-native|spezi-template)
     REMOTE_URL="https://github.com/StanfordSpezi/SpeziTemplateApplication"
     ;;
   *)
-    echo "Unknown project: $PROJECT_NAME" >&2
-    echo "Supported projects: rn-cs342-template | spezi-template" >&2
+    echo "Unknown platform: $PROJECT_NAME" >&2
+    echo "Supported platforms: react-native | apple-native" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

This PR makes the SpeziVibe workflow explicit and consistent across every skill, doc, and the landing page, and adds significant polish to the landing experience.

### Workflow: plan first, clone last

Previously the docs and the orchestrator suggested cloning a Spezi template early in the process, which left planning briefs orphaned in the directory where they were created. This PR makes the workflow explicit:

1. Plan in any working directory — briefs land in `docs/planning/*.md`
2. `app-build-planner` produces `docs/implementation-plan.md`
3. **Then** `spezi-platform-selection` (optionally) clones the matching Spezi template and **moves the planning briefs into the cloned repo** so the coding agent has full context
4. The AI coding agent reads the implementation plan and writes the code

The template path is now also clearly optional — a new "Building Without a Spezi Template" section in How It Works covers users on other stacks or existing repos.

### Skill changes

- `build-an-app/SKILL.md`: execution order rewritten — planning skills first, `app-build-planner` next, `spezi-platform-selection` last
- `spezi-platform-selection/SKILL.md`: now runs **after** planning, adds a "Carry Planning Forward" step that moves `docs/planning/` and `docs/implementation-plan.md` into the cloned repo; adds "When Not To Use" for the template-skip path; frontmatter description updated
- `app-build-planner/SKILL.md`: no longer assumes a cloned template; accepts "Other" as a platform answer; removed all references to repo-local build skills
- `apple-native-modules.md` reference: title and intro use the new framing

### Terminology + repo names

- User-facing platform choice is consistently **React Native** vs **Apple-native**
- React Native template repo URL updated to `StanfordSpezi/SpeziVibeReactNativeTemplate` (was `CS342/ReactNativeTemplateApplication`) in `.gitmodules` and `scripts/clone-template.sh`
- Clone script keys are `react-native` | `apple-native` (legacy `spezi-template` alias kept for now; CS342 alias removed)

### Docs

- New `docs/docs/how-it-works.md` — the canonical workflow explanation with file-layout diagrams (before/after clone) and a Building-Without-a-Template section
- `getting-started.md` rewritten with prerequisites, per-tool install, manual install, verification steps, and a concrete first-prompt example
- Every individual skill doc has a copy-paste install snippet under its title
- `skills.md` overview table reordered to workflow order with absolute output paths
- `sidebars.js` and per-doc `sidebar_position` values aligned to the workflow order
- README "Where To Start" steps reordered; skill catalog + per-skill detail sections reordered to match; the template-clone step is now marked optional with a skip callout
- `CLAUDE.md` and `AGENTS.md` aligned

### Landing page polish

- Display typography swapped to **Geist** (300–900) with **Instrument Serif italic** on the "digital health" highlight for editorial contrast
- Install command has a rotating conic-gradient ring plus radial glow halo
- Primary CTA gains a warm accent shine sweep on hover
- Skills section reorganized: a featured "Start here" card for `build-an-app` plus three labeled phases (**Plan / Build / Ship & maintain**) with uniform card grids — replaces the previous mixed-size bento layout that was hard to scan
- Each skill card is a link to its docs page, with a fade-in arrow on hover; the example terminal inside `build-an-app` gets a window-chrome treatment
- "What is SpeziVibe" and "How it works" steps reworded to reflect the planning-first workflow
- Rocket logo settled into a tilted, gently breathing pose (no more vertical hover)

## Test plan

- [x] Open the docs site locally (`cd docs && npm start`) and click through Getting Started → How SpeziVibe Works → Skills Overview → each skill page → back to landing — narrative should be coherent at every hop
- [x] Verify all install snippets on individual skill docs render correctly
- [x] Verify dark and light themes render the new typography and install-block animations
- [x] Walk through the landing page on mobile — skills grid should collapse correctly
- [x] Run `scripts/clone-template.sh react-native /tmp/check-rn` and `scripts/clone-template.sh apple-native /tmp/check-ios` against the documented keys (and confirm `bogus` is rejected)
- [x] Spot-check `build-an-app` end-to-end: give it a hypothetical app description and confirm the proposed plan matches the execution-order table in `build-an-app/SKILL.md`