### PR TITLE
Add 'Try this skill' deeplinks for Claude and ChatGPT

### DIFF
--- a/docs/docs/skills/app-build-planner.md
+++ b/docs/docs/skills/app-build-planner.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="app-build-planner" />
+
 Reads planning documents from the other skills and produces a milestone-based implementation plan. Does not generate code — your AI coding agent uses the plan to write the code. See [How SpeziVibe Works](/docs/how-it-works).
 
 ## Inputs

--- a/docs/docs/skills/biodesign-needs-finding.md
+++ b/docs/docs/skills/biodesign-needs-finding.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="biodesign-needs-finding" />
+
 Walks you through a Stanford Biodesign-style needs-finding process to define a clear, solution-free problem statement.
 
 ## How It Works

--- a/docs/docs/skills/build-an-app.md
+++ b/docs/docs/skills/build-an-app.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="build-an-app" />
+
 The main entry point for SpeziVibe. Describe what you want to build and this skill determines which planning skills apply, walks you through each one in sequence, and produces an implementation plan your AI coding agent can build from. See [How SpeziVibe Works](/docs/how-it-works).
 
 ## How It Works

--- a/docs/docs/skills/digital-health-compliance-planning.md
+++ b/docs/docs/skills/digital-health-compliance-planning.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="digital-health-compliance-planning" />
+
 Helps you reason through which compliance domains apply to your project and what controls you should consider. Framework-agnostic — recommends capabilities, not specific implementations.
 
 ## Domains Assessed

--- a/docs/docs/skills/digital-health-study-planning.md
+++ b/docs/docs/skills/digital-health-study-planning.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="digital-health-study-planning" />
+
 Helps plan a digital health research protocol. Platform-agnostic — focuses on the study design, not the app stack.
 
 ## What It Covers

--- a/docs/docs/skills/digital-health-ux-planning.md
+++ b/docs/docs/skills/digital-health-ux-planning.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="digital-health-ux-planning" />
+
 Plans user experience journeys for digital health products. Platform-agnostic — focuses on user goals and decision points, not specific screens.
 
 ## What It Covers

--- a/docs/docs/skills/fhir-data-model-design.md
+++ b/docs/docs/skills/fhir-data-model-design.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="fhir-data-model-design" />
+
 Maps clinical data types to specific FHIR R4 resources, terminology bindings, and relationships. Unlike most other skills, this one is expert-driven — it provides recommendations rather than asking Socratic questions.
 
 ## What It Produces

--- a/docs/docs/skills/health-data-model-planning.md
+++ b/docs/docs/skills/health-data-model-planning.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="health-data-model-planning" />
+
 Plans health data entities, relationships, and governance choices before committing to a storage layer. Biased toward FHIR for clinically meaningful or shareable data, but allows opt-out with justification.
 
 ## What It Covers

--- a/docs/docs/skills/keep-a-changelog-generator.md
+++ b/docs/docs/skills/keep-a-changelog-generator.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="keep-a-changelog-generator" />
+
 Generates changelog entries from git history in the [Keep a Changelog](https://keepachangelog.com) format.
 
 ## How It Works

--- a/docs/docs/skills/project-wiki.md
+++ b/docs/docs/skills/project-wiki.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="project-wiki" />
+
 Set up and maintain a persistent, AI-managed knowledge base for a digital health project — turning clinical observations, papers, interviews, and planning docs into a compounding, interlinked wiki.
 
 ## How It Works

--- a/docs/docs/skills/release-notes-generator.md
+++ b/docs/docs/skills/release-notes-generator.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="release-notes-generator" />
+
 Creates user-facing release notes with feature highlights, fixes, breaking changes, and migration guidance.
 
 ## Output Sections

--- a/docs/docs/skills/spezi-platform-selection.md
+++ b/docs/docs/skills/spezi-platform-selection.md
@@ -14,6 +14,8 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
+<TryThisSkill skill="spezi-platform-selection" />
+
 Runs **after** the other planning skills finish, when the user is ready to build with a Spezi template. Uses the planning briefs to recommend a platform, clones the matching Spezi starter template, and moves the existing `docs/planning/` and `docs/implementation-plan.md` into the cloned repo so the coding agent has full context.
 
 Skip this skill if you're not using a Spezi template — your planning briefs and implementation plan work just as well in any codebase. See [Building Without a Spezi Template](/docs/how-it-works#building-without-a-spezi-template).

--- a/docs/src/components/TryThisSkill.jsx
+++ b/docs/src/components/TryThisSkill.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+const SKILL_BASE = 'https://raw.githubusercontent.com/StanfordSpezi/SpeziVibe/main/skills';
+
+function buildPrompt(skill) {
+  const skillUrl = `${SKILL_BASE}/${skill}/SKILL.md`;
+  return [
+    `Please act as the SpeziVibe \`${skill}\` skill and walk me through it interactively.`,
+    '',
+    'Fetch the skill instructions from this URL and follow them step by step:',
+    skillUrl,
+    '',
+    "When a step would normally save a markdown file to a project, show the file content in a code block instead so I can copy it. Don't simulate my answers — wait for me to respond.",
+  ].join('\n');
+}
+
+const TARGETS = [
+  {
+    key: 'claude',
+    label: 'Try in Claude',
+    url: (encoded) => `https://claude.ai/new?q=${encoded}`,
+  },
+  {
+    key: 'chatgpt',
+    label: 'Try in ChatGPT',
+    url: (encoded) => `https://chatgpt.com/?q=${encoded}`,
+  },
+];
+
+const ExternalIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="try-button-ext">
+    <path d="M7 17L17 7M17 7H7M17 7v10" />
+  </svg>
+);
+
+const PlayIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <polygon points="6 4 20 12 6 20 6 4" />
+  </svg>
+);
+
+export default function TryThisSkill({skill}) {
+  const encoded = encodeURIComponent(buildPrompt(skill));
+  return (
+    <div className="try-this-skill">
+      {TARGETS.map(({key, label, url}) => (
+        <a
+          key={key}
+          href={url(encoded)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`try-button try-button--${key}`}
+          aria-label={`${label} — opens in a new tab`}
+        >
+          <PlayIcon />
+          <span>{label}</span>
+          <ExternalIcon />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -858,6 +858,76 @@ a.skill-card-link:hover .skill-card-arrow,
   transform: translateX(0);
 }
 
+/* -- Try this skill buttons (used inside skill docs) -- */
+.try-this-skill {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0 0 1.75rem 0;
+}
+
+.try-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.65rem 1.15rem;
+  color: #fff !important;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-decoration: none !important;
+  border: 1px solid rgba(255,255,255,0.08);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.try-button--claude {
+  background: linear-gradient(135deg, #d97757 0%, #c2603d 100%);
+  box-shadow: 0 4px 14px -4px rgba(217, 119, 87, 0.45);
+}
+
+.try-button--chatgpt {
+  background: linear-gradient(135deg, #1f8a6e 0%, #0d6c54 100%);
+  box-shadow: 0 4px 14px -4px rgba(31, 138, 110, 0.45);
+}
+
+.try-button:hover,
+.try-button:focus-visible {
+  transform: translateY(-1px);
+  color: #fff !important;
+  text-decoration: none !important;
+  filter: brightness(1.06);
+}
+
+.try-button--claude:hover,
+.try-button--claude:focus-visible {
+  box-shadow: 0 6px 22px -6px rgba(217, 119, 87, 0.65);
+}
+
+.try-button--chatgpt:hover,
+.try-button--chatgpt:focus-visible {
+  box-shadow: 0 6px 22px -6px rgba(31, 138, 110, 0.65);
+}
+
+.try-button:focus-visible {
+  outline: 2px solid rgba(255,255,255,0.5);
+  outline-offset: 3px;
+}
+
+.try-button svg {
+  flex-shrink: 0;
+}
+
+.try-button .try-button-ext {
+  opacity: 0.7;
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.try-button:hover .try-button-ext {
+  opacity: 1;
+  transform: translate(2px, -2px);
+}
+
 @media (max-width: 1024px) {
   .skill-phase-grid {
     grid-template-columns: repeat(2, 1fr);

--- a/docs/src/theme/MDXComponents.js
+++ b/docs/src/theme/MDXComponents.js
@@ -1,0 +1,7 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import TryThisSkill from '@site/src/components/TryThisSkill';
+
+export default {
+  ...MDXComponents,
+  TryThisSkill,
+};


### PR DESCRIPTION
## Summary

Lets users try a skill before installing it — adds a "Try in Claude" and "Try in ChatGPT" button on every skill doc page that opens a pre-filled chat session pointing the assistant at the skill's `SKILL.md` on GitHub.

This PR exists because the original PR #54 was merged into the (now-stale) `clarify-workflow-and-polish-landing` branch instead of `main` — the playground feature never reached `main` after the workflow-restructure PR landed. This re-merges it correctly.

## What changes

Each skill doc now shows two branded buttons under the install admonition. Clicking either opens a new chat with this prompt pre-filled:

> Please act as the SpeziVibe \`<skill>\` skill and walk me through it interactively.
>
> Fetch the skill instructions from this URL and follow them step by step:
> https://raw.githubusercontent.com/StanfordSpezi/SpeziVibe/main/skills/\<skill\>/SKILL.md
>
> When a step would normally save a markdown file to a project, show the file content in a code block instead so I can copy it. Don't simulate my answers — wait for me to respond.

- **Claude** → `https://claude.ai/new?q=<encoded prompt>`
- **ChatGPT** → `https://chatgpt.com/?q=<encoded prompt>`

## Implementation

- `docs/src/components/TryThisSkill.jsx` — builds the prompt and renders both buttons
- `docs/src/theme/MDXComponents.js` — registers the component globally so skill docs can use `<TryThisSkill skill="..." />` with no per-file imports
- `docs/src/css/custom.css` — two gradient button styles (Claude warm-orange / ChatGPT teal-green) with hover lift, focus ring, and external-link arrow
- Each of the 12 skill docs got a one-line addition under the install admonition

## Cost / hosting

Zero — chat runs on the user's own Claude or ChatGPT account. No tokens or infrastructure on our side.

## Test plan

- [ ] Visit any skill page (e.g. `/docs/skills/biodesign-needs-finding`) — both buttons render under the install admonition
- [ ] Click "Try in Claude" — opens `claude.ai/new` with the skill-specific prompt pre-filled
- [ ] Click "Try in ChatGPT" — opens `chatgpt.com` with the same prompt
- [ ] Confirm the assistant fetches the SKILL.md and walks through the skill conversationally
- [ ] Check both dark and light themes; tab through to verify focus rings