### PR TITLE
Robustify Try-in-chat: pre-list dependencies, hide buttons that need local execution

### DIFF
--- a/docs/docs/skills/keep-a-changelog-generator.md
+++ b/docs/docs/skills/keep-a-changelog-generator.md
@@ -14,8 +14,6 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
-<TryThisSkill skill="keep-a-changelog-generator" />
-
 Generates changelog entries from git history in the [Keep a Changelog](https://keepachangelog.com) format.
 
 ## How It Works

--- a/docs/docs/skills/project-wiki.md
+++ b/docs/docs/skills/project-wiki.md
@@ -14,8 +14,6 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
-<TryThisSkill skill="project-wiki" />
-
 Set up and maintain a persistent, AI-managed knowledge base for a digital health project — turning clinical observations, papers, interviews, and planning docs into a compounding, interlinked wiki.
 
 ## How It Works

--- a/docs/docs/skills/release-notes-generator.md
+++ b/docs/docs/skills/release-notes-generator.md
@@ -14,8 +14,6 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
-<TryThisSkill skill="release-notes-generator" />
-
 Creates user-facing release notes with feature highlights, fixes, breaking changes, and migration guidance.
 
 ## Output Sections

--- a/docs/docs/skills/spezi-platform-selection.md
+++ b/docs/docs/skills/spezi-platform-selection.md
@@ -14,8 +14,6 @@ Or install all skills: `npx skills add StanfordSpezi/SpeziVibe --all`. See the [
 
 :::
 
-<TryThisSkill skill="spezi-platform-selection" />
-
 Runs **after** the other planning skills finish, when the user is ready to build with a Spezi template. Uses the planning briefs to recommend a platform, clones the matching Spezi starter template, and moves the existing `docs/planning/` and `docs/implementation-plan.md` into the cloned repo so the coding agent has full context.
 
 Skip this skill if you're not using a Spezi template — your planning briefs and implementation plan work just as well in any codebase. See [Building Without a Spezi Template](/docs/how-it-works#building-without-a-spezi-template).

--- a/docs/src/components/TryThisSkill.jsx
+++ b/docs/src/components/TryThisSkill.jsx
@@ -2,16 +2,81 @@ import React from 'react';
 
 const SKILL_BASE = 'https://raw.githubusercontent.com/StanfordSpezi/SpeziVibe/main/skills';
 
+// Skills with hard dependencies on other files/skills. Listing them upfront
+// makes the assistant fetch eagerly instead of improvising mid-conversation.
+const DEPENDENCIES = {
+  'build-an-app': {
+    kind: 'orchestrator',
+    subSkills: [
+      'biodesign-needs-finding',
+      'spezi-platform-selection',
+      'digital-health-ux-planning',
+      'digital-health-study-planning',
+      'health-data-model-planning',
+      'fhir-data-model-design',
+      'digital-health-compliance-planning',
+      'app-build-planner',
+    ],
+  },
+  'app-build-planner': {
+    kind: 'references',
+    files: [
+      'references/react-native-packages.md',
+      'references/apple-native-modules.md',
+      'references/milestone-patterns.md',
+    ],
+  },
+  'spezi-platform-selection': {
+    kind: 'references',
+    files: [
+      'references/platform-decision.md',
+      'references/setup-guide.md',
+    ],
+  },
+};
+
 function buildPrompt(skill) {
   const skillUrl = `${SKILL_BASE}/${skill}/SKILL.md`;
-  return [
+  const dep = DEPENDENCIES[skill];
+
+  const lines = [
     `Please act as the SpeziVibe \`${skill}\` skill and walk me through it interactively.`,
     '',
-    'Fetch the skill instructions from this URL and follow them step by step:',
+    'STEP 1 — Fetch the skill instructions from this URL and read them carefully:',
     skillUrl,
     '',
-    "When a step would normally save a markdown file to a project, show the file content in a code block instead so I can copy it. Don't simulate my answers — wait for me to respond.",
-  ].join('\n');
+  ];
+
+  if (dep && dep.kind === 'orchestrator') {
+    lines.push(
+      `STEP 2 — This skill is an orchestrator. It will instruct you to run other skills in sequence. When it tells you to run a sub-skill, you MUST fetch that sub-skill's SKILL.md first and follow ITS instructions before continuing — do not improvise based on the skill name alone.`,
+      '',
+      'Sub-skill URLs (fetch each when the orchestrator tells you to run it):',
+      ...dep.subSkills.map((s) => `- ${s}: ${SKILL_BASE}/${s}/SKILL.md`),
+      '',
+      `If any sub-skill references additional files (e.g. \`references/foo.md\`), fetch them from ${SKILL_BASE}/<sub-skill-name>/<relative-path>.`,
+      '',
+    );
+  } else if (dep && dep.kind === 'references') {
+    lines.push(
+      'STEP 2 — This skill references additional files. When the instructions tell you to read one, fetch it from these URLs:',
+      ...dep.files.map((f) => `- ${f}: ${SKILL_BASE}/${skill}/${f}`),
+      '',
+    );
+  } else {
+    lines.push(
+      'If the skill references other files or other skills by name, fetch them from the same repository:',
+      `- Files inside this skill (e.g. \`references/foo.md\`): ${SKILL_BASE}/${skill}/<relative-path>`,
+      `- Other skills (e.g. \`biodesign-needs-finding\`): ${SKILL_BASE}/<skill-name>/SKILL.md`,
+      '',
+    );
+  }
+
+  lines.push(
+    "STEP 3 — Walk me through the skill interactively. When a step would normally save a markdown file to a project, show the file content in a code block instead so I can copy it. Don't simulate my answers — wait for me to respond.",
+  );
+
+  return lines.join('\n');
 }
 
 const TARGETS = [


### PR DESCRIPTION
## Summary

Two follow-ups to PR #55 that emerged from testing the playground:

### 1. Stronger prompts for skills with dependencies

When testing the `build-an-app` deeplink, Claude received the orchestrator's instructions but improvised on sub-skills instead of fetching their SKILL.md files. The prompt didn't make it clear they had to be fetched.

The deeplink prompt is now structured as numbered steps and lists every dependency URL upfront:

- **`build-an-app`** — lists all 8 sub-skill URLs and uses directive language: *"you MUST fetch that sub-skill's SKILL.md first and follow ITS instructions before continuing — do not improvise based on the skill name alone."*
- **`app-build-planner`** — lists its 3 reference file URLs (`react-native-packages.md`, `apple-native-modules.md`, `milestone-patterns.md`) so the assistant doesn't have to derive paths
- **`spezi-platform-selection`** — lists its 2 reference file URLs (rendered for completeness even though its button is hidden — see #2)
- **Atomic planning skills** — unchanged general guidance

A `DEPENDENCIES` map in `TryThisSkill.jsx` keeps this declarative and easy to extend when more skills get dependencies.

`build-an-app`'s deeplink URL is now ~2.7KB — well under all browser/server URL limits.

### 2. Hide buttons on skills that can't run in a chat

These skills need shell or filesystem access that a browser chat session doesn't have, so the buttons are hidden on their docs:

| Skill | Why it needs local execution |
|---|---|
| `spezi-platform-selection` | runs `git clone` |
| `project-wiki` | creates a `wiki/` directory and edits CLAUDE.md |
| `keep-a-changelog-generator` | reads `git log` |
| `release-notes-generator` | reads `git log` |

The skills are still listed in the catalog and have docs — they just don't get a Try button because the meaningful output requires a local install.

The 8 remaining skills (`build-an-app`, `biodesign-needs-finding`, `digital-health-ux-planning`, `digital-health-study-planning`, `digital-health-compliance-planning`, `health-data-model-planning`, `fhir-data-model-design`, `app-build-planner`) all produce markdown briefs that work great in a chat.

## Test plan

- [x] Atomic skill (e.g. `biodesign-needs-finding`) still works in Claude
- [x] `build-an-app` orchestrator now actually fetches sub-skill SKILL.md files when the orchestrator says to run one (the bug this PR fixes)
- [x] Hidden-button skills (`spezi-platform-selection`, `project-wiki`, `keep-a-changelog-generator`, `release-notes-generator`) show no Try buttons on their docs pages
- [x] Other 8 skills still show both Try-in-Claude and Try-in-ChatGPT buttons