### PR TITLE
Add interactive Workshop tab

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -70,6 +70,11 @@ const config = {
             label: 'Docs',
           },
           {
+            to: '/workshop',
+            label: 'Workshop',
+            position: 'left',
+          },
+          {
             to: '/about',
             label: 'About',
             position: 'left',
@@ -94,6 +99,10 @@ const config = {
               {
                 label: 'Skills',
                 to: '/docs/skills',
+              },
+              {
+                label: 'Workshop',
+                to: '/workshop',
               },
               {
                 label: 'About',

--- a/docs/src/components/TryThisSkill.jsx
+++ b/docs/src/components/TryThisSkill.jsx
@@ -35,17 +35,24 @@ const DEPENDENCIES = {
   },
 };
 
-function buildPrompt(skill) {
+export function buildPrompt(skill, {context} = {}) {
   const skillUrl = `${SKILL_BASE}/${skill}/SKILL.md`;
   const dep = DEPENDENCIES[skill];
+  const ctx = context && context.trim();
 
-  const lines = [
-    `Please act as the SpeziVibe \`${skill}\` skill and walk me through it interactively.`,
+  const lines = [];
+  if (ctx) {
+    lines.push(`I'm planning a digital health app: ${ctx}.`, '');
+  }
+  lines.push(
+    `Please act as the SpeziVibe \`${skill}\` skill and walk me through it interactively${
+      ctx ? ', using the app idea above as our starting point' : ''
+    }.`,
     '',
     'STEP 1 — Fetch the skill instructions from this URL and read them carefully:',
     skillUrl,
     '',
-  ];
+  );
 
   if (dep && dep.kind === 'orchestrator') {
     lines.push(
@@ -83,11 +90,13 @@ const TARGETS = [
   {
     key: 'claude',
     label: 'Try in Claude',
+    Icon: ClaudeMark,
     url: (encoded) => `https://claude.ai/new?q=${encoded}`,
   },
   {
     key: 'chatgpt',
     label: 'Try in ChatGPT',
+    Icon: OpenAIMark,
     url: (encoded) => `https://chatgpt.com/?q=${encoded}`,
   },
 ];
@@ -98,17 +107,29 @@ const ExternalIcon = () => (
   </svg>
 );
 
-const PlayIcon = () => (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-    <polygon points="6 4 20 12 6 20 6 4" />
-  </svg>
-);
-
-export default function TryThisSkill({skill}) {
-  const encoded = encodeURIComponent(buildPrompt(skill));
+// Official brand marks (from the simple-icons set). Rendered monochrome —
+// they inherit the button's text color, so the logos stay unmodified.
+function ClaudeMark() {
   return (
-    <div className="try-this-skill">
-      {TARGETS.map(({key, label, url}) => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" />
+  </svg>
+  );
+}
+
+function OpenAIMark() {
+  return (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+  </svg>
+  );
+}
+
+export function TryButtons({prompt, className}) {
+  const encoded = encodeURIComponent(prompt);
+  return (
+    <div className={`try-this-skill${className ? ` ${className}` : ''}`}>
+      {TARGETS.map(({key, label, Icon, url}) => (
         <a
           key={key}
           href={url(encoded)}
@@ -117,11 +138,15 @@ export default function TryThisSkill({skill}) {
           className={`try-button try-button--${key}`}
           aria-label={`${label} — opens in a new tab`}
         >
-          <PlayIcon />
+          <Icon />
           <span>{label}</span>
           <ExternalIcon />
         </a>
       ))}
     </div>
   );
+}
+
+export default function TryThisSkill({skill}) {
+  return <TryButtons prompt={buildPrompt(skill)} />;
 }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -854,13 +854,14 @@ a.skill-card-link:hover .skill-card-arrow {
 }
 
 .try-button--claude {
-  background: linear-gradient(135deg, #d97757 0%, #c2603d 100%);
+  background: #d97757;
   box-shadow: 0 4px 14px -4px rgba(217, 119, 87, 0.45);
 }
 
 .try-button--chatgpt {
-  background: linear-gradient(135deg, #1f8a6e 0%, #0d6c54 100%);
-  box-shadow: 0 4px 14px -4px rgba(31, 138, 110, 0.45);
+  background: #000000;
+  border-color: rgba(255, 255, 255, 0.22);
+  box-shadow: 0 4px 14px -4px rgba(0, 0, 0, 0.55);
 }
 
 .try-button:hover,
@@ -878,7 +879,9 @@ a.skill-card-link:hover .skill-card-arrow {
 
 .try-button--chatgpt:hover,
 .try-button--chatgpt:focus-visible {
-  box-shadow: 0 6px 22px -6px rgba(31, 138, 110, 0.65);
+  background: #171717;
+  border-color: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 6px 22px -6px rgba(0, 0, 0, 0.7);
 }
 
 .try-button:focus-visible {
@@ -1064,7 +1067,339 @@ a.skill-card-link:hover .skill-card-arrow {
   transform: translate(3px, -3px);
 }
 
+/* -- Workshop page -- */
+.ws-wrap {
+  position: relative;
+  z-index: 1;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 6rem 1.5rem 7rem;
+}
+
+.ws-title {
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0.75rem 0 0;
+  text-align: center;
+}
+
+.ws-subtitle {
+  margin: 1rem auto 0;
+  max-width: 560px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.ws-idea {
+  margin-top: 3rem;
+  padding: 1.5rem 1.6rem;
+  border-radius: 16px;
+  background: rgba(232, 81, 26, 0.05);
+  border: 1px solid rgba(232, 81, 26, 0.18);
+}
+
+.ws-idea-label {
+  display: block;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.ws-idea-input {
+  width: 100%;
+  resize: vertical;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border-subtle);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ws-idea-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(232, 81, 26, 0.15);
+}
+
+.ws-idea-input::placeholder {
+  color: var(--text-dim);
+}
+
+.ws-idea-hint {
+  margin: 0.6rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.ws-progress {
+  margin-top: 2.5rem;
+}
+
+.ws-progress-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 0.6rem;
+}
+
+.ws-progress-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.ws-reset {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  transition: color 0.2s ease;
+}
+
+.ws-reset:hover {
+  color: var(--accent);
+}
+
+.ws-progress-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--border-subtle);
+  overflow: hidden;
+}
+
+.ws-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-light, var(--accent)));
+  transition: width 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ws-steps {
+  list-style: none;
+  margin: 2.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ws-step {
+  display: flex;
+  gap: 1.1rem;
+  padding: 1.5rem;
+  transition: border-color 0.25s ease, opacity 0.25s ease;
+}
+
+.ws-step.is-done {
+  opacity: 0.62;
+}
+
+.ws-step.is-active {
+  border-color: rgba(232, 81, 26, 0.4);
+}
+
+.ws-step-num {
+  flex: 0 0 36px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border-subtle);
+}
+
+.ws-step.is-active .ws-step-num {
+  color: var(--accent);
+  border-color: rgba(232, 81, 26, 0.45);
+  background: rgba(232, 81, 26, 0.1);
+}
+
+.ws-step.is-done .ws-step-num {
+  color: #fff;
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.ws-step-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.ws-step-title {
+  margin: 0.25rem 0 0;
+  font-size: 1.15rem;
+  letter-spacing: -0.01em;
+}
+
+.ws-step-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin: 0.5rem 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.74rem;
+}
+
+.ws-step-skill {
+  color: var(--accent);
+}
+
+.ws-step-arrow {
+  color: var(--text-dim);
+}
+
+.ws-step-output {
+  color: var(--text-muted);
+}
+
+.ws-step-blurb {
+  margin: 0.7rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.97rem;
+  line-height: 1.6;
+}
+
+.ws-code {
+  position: relative;
+  margin-top: 1.1rem;
+  padding: 0.9rem 5rem 0.9rem 1rem;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid var(--border-subtle);
+}
+
+.ws-code code {
+  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--text);
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ws-copy {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 7px;
+  background: rgba(232, 81, 26, 0.1);
+  border: 1px solid rgba(232, 81, 26, 0.25);
+  color: var(--accent);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.ws-copy:hover {
+  background: rgba(232, 81, 26, 0.18);
+  border-color: rgba(232, 81, 26, 0.45);
+}
+
+.ws-step-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 1.1rem;
+}
+
+.try-this-skill.ws-try {
+  margin: 0;
+}
+
+.ws-done-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.65rem 1.15rem;
+  border-radius: 10px;
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  font-weight: 600;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ws-done-btn:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.ws-done-btn.is-done {
+  background: rgba(232, 81, 26, 0.1);
+  border-color: rgba(232, 81, 26, 0.35);
+  color: var(--accent);
+}
+
+.ws-complete {
+  margin-top: 2rem;
+  padding: 2.5rem;
+  text-align: center;
+}
+
+.ws-complete-badge {
+  display: inline-block;
+  margin-bottom: 1rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(232, 81, 26, 0.1);
+  border: 1px solid rgba(232, 81, 26, 0.25);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+
+.ws-complete h2 {
+  margin: 0 0 0.75rem;
+}
+
+.ws-complete p {
+  margin: 0 auto 0.75rem;
+  max-width: 520px;
+  color: var(--text-muted);
+  line-height: 1.65;
+}
+
+.ws-complete-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
 @media (max-width: 640px) {
+  .ws-step {
+    padding: 1.25rem;
+    gap: 0.85rem;
+  }
   .team-grid {
     grid-template-columns: 1fr;
     max-width: 280px;

--- a/docs/src/pages/workshop.js
+++ b/docs/src/pages/workshop.js
@@ -1,0 +1,277 @@
+import React, {useEffect, useState} from 'react';
+import Layout from '@theme/Layout';
+import {buildPrompt, TryButtons} from '../components/TryThisSkill';
+
+const STORAGE_KEY = 'spezivibe-workshop-v1';
+const INSTALL_CMD = 'npx skills add StanfordSpezi/SpeziVibe --all';
+
+const STEPS = [
+  {
+    id: 'install',
+    title: 'Install the planning skills',
+    blurb: 'One command adds the SpeziVibe skills to your AI coding tool — Claude Code, Cursor, Copilot, Codex, Gemini, and more.',
+    kind: 'command',
+    text: INSTALL_CMD,
+  },
+  {
+    id: 'need',
+    title: 'Define the need',
+    blurb: 'Turn your idea into a sharp problem statement using the Stanford Biodesign needs-finding process.',
+    skill: 'biodesign-needs-finding',
+    output: 'need-statement.md',
+    prompt: (idea) =>
+      `I want to build ${idea}. Use the biodesign-needs-finding skill to walk me through defining a clear problem statement.`,
+  },
+  {
+    id: 'compliance',
+    title: 'Plan for compliance',
+    blurb: 'Surface the privacy, regulatory, and research questions — HIPAA, IRB, FDA, GDPR — early, before any code.',
+    skill: 'digital-health-compliance-planning',
+    output: 'compliance-brief.md',
+    prompt: (idea) =>
+      `Based on my need statement for ${idea}, run the digital-health-compliance-planning skill to identify which compliance domains and controls apply.`,
+  },
+  {
+    id: 'data',
+    title: 'Model your health data',
+    blurb: 'Define the core health data entities, how they relate, and what they need for interoperability.',
+    skill: 'health-data-model-planning',
+    output: 'data-model-brief.md',
+    prompt: (idea) =>
+      `Using my planning so far for ${idea}, run the health-data-model-planning skill to define the data entities, relationships, and interoperability needs.`,
+  },
+  {
+    id: 'ux',
+    title: 'Design the experience',
+    blurb: 'Map the user journeys, onboarding, and day-to-day workflows for patients and clinicians.',
+    skill: 'digital-health-ux-planning',
+    output: 'ux-brief.md',
+    prompt: (idea) =>
+      `Using my planning so far for ${idea}, run the digital-health-ux-planning skill to plan the user journeys and onboarding.`,
+  },
+];
+
+function ScrollReveal() {
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('active');
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {threshold: 0.1},
+    );
+    document.querySelectorAll('.reveal').forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+  return null;
+}
+
+function stepText(step, idea) {
+  const ideaText = idea.trim() || 'my digital health app';
+  return step.kind === 'command' ? step.text : step.prompt(ideaText);
+}
+
+function CopyBlock({text, copied, onCopy}) {
+  return (
+    <div className="ws-code">
+      <code>{text}</code>
+      <button
+        type="button"
+        className="ws-copy"
+        aria-label="Copy to clipboard"
+        onClick={onCopy}
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export default function Workshop() {
+  const [idea, setIdea] = useState('');
+  const [done, setDone] = useState({});
+  const [copiedId, setCopiedId] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Hydrate from localStorage after mount (avoids SSR mismatch).
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const saved = JSON.parse(raw);
+        if (typeof saved.idea === 'string') setIdea(saved.idea);
+        if (saved.done && typeof saved.done === 'object') setDone(saved.done);
+      }
+    } catch (e) {
+      /* ignore */
+    }
+    setLoaded(true);
+  }, []);
+
+  // Persist on change.
+  useEffect(() => {
+    if (!loaded) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({idea, done}));
+    } catch (e) {
+      /* ignore */
+    }
+  }, [idea, done, loaded]);
+
+  const doneCount = STEPS.filter((s) => done[s.id]).length;
+  const total = STEPS.length;
+  const pct = Math.round((doneCount / total) * 100);
+  const activeIndex = STEPS.findIndex((s) => !done[s.id]);
+  const allDone = doneCount === total;
+
+  const copy = (step) => {
+    const text = stepText(step, idea);
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(() => {
+        setCopiedId(step.id);
+        setTimeout(() => setCopiedId((c) => (c === step.id ? null : c)), 2000);
+      });
+    }
+  };
+
+  const toggle = (id) => setDone((d) => ({...d, [id]: !d[id]}));
+  const reset = () => {
+    setIdea('');
+    setDone({});
+  };
+
+  return (
+    <Layout
+      title="Workshop"
+      description="A step-by-step workshop that takes a simple idea and walks you through planning a digital health app, right in your browser."
+      wrapperClassName="landing-page"
+    >
+      <div className="aurora-base"></div>
+      <div className="aurora-accent"></div>
+      <div className="grid-pattern"></div>
+      <ScrollReveal />
+
+      <section className="ws-wrap">
+        <div className="reveal">
+          <p className="section-label">Workshop</p>
+          <h1 className="ws-title">Plan your app, step by step</h1>
+          <p className="ws-subtitle">
+            Start with a simple idea. Each step gives you a prompt to paste into your AI
+            coding tool — by the end you&rsquo;ll have a folder of planning briefs ready to build from.
+          </p>
+        </div>
+
+        <div className="ws-idea reveal reveal-delay-1">
+          <label className="ws-idea-label" htmlFor="ws-idea-input">
+            What do you want to build?
+          </label>
+          <textarea
+            id="ws-idea-input"
+            className="ws-idea-input"
+            rows={2}
+            placeholder="e.g. a medication tracker for post-transplant patients"
+            value={idea}
+            onChange={(e) => setIdea(e.target.value)}
+          />
+          <p className="ws-idea-hint">
+            We&rsquo;ll weave this into every prompt below. You can edit it any time.
+          </p>
+        </div>
+
+        <div className="ws-progress reveal">
+          <div className="ws-progress-top">
+            <span className="ws-progress-label">
+              {doneCount} of {total} complete
+            </span>
+            {doneCount > 0 && (
+              <button type="button" className="ws-reset" onClick={reset}>
+                Reset
+              </button>
+            )}
+          </div>
+          <div className="ws-progress-bar">
+            <div className="ws-progress-fill" style={{width: `${pct}%`}}></div>
+          </div>
+        </div>
+
+        <ol className="ws-steps">
+          {STEPS.map((step, i) => {
+            const isDone = !!done[step.id];
+            const isActive = !isDone && i === activeIndex;
+            return (
+              <li
+                key={step.id}
+                className={`glass-card ws-step${isDone ? ' is-done' : ''}${
+                  isActive ? ' is-active' : ''
+                }`}
+              >
+                <div className="ws-step-num" aria-hidden="true">
+                  {isDone ? '✓' : i + 1}
+                </div>
+                <div className="ws-step-body">
+                  <h3 className="ws-step-title">{step.title}</h3>
+                  {step.skill && (
+                    <p className="ws-step-meta">
+                      <span className="ws-step-skill">{step.skill}</span>
+                      <span className="ws-step-arrow">→</span>
+                      <span className="ws-step-output">{step.output}</span>
+                    </p>
+                  )}
+                  <p className="ws-step-blurb">{step.blurb}</p>
+                  <CopyBlock
+                    text={stepText(step, idea)}
+                    copied={copiedId === step.id}
+                    onCopy={() => copy(step)}
+                  />
+                  <div className="ws-step-actions">
+                    {step.skill && (
+                      <TryButtons
+                        className="ws-try"
+                        prompt={buildPrompt(step.skill, {context: idea})}
+                      />
+                    )}
+                    <button
+                      type="button"
+                      className={`ws-done-btn${isDone ? ' is-done' : ''}`}
+                      onClick={() => toggle(step.id)}
+                    >
+                      {isDone ? '✓ Done' : 'Mark done'}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+
+        {allDone && (
+          <div className="glass-card ws-complete reveal">
+            <div className="ws-complete-badge">🎉 Plan complete</div>
+            <h2>You&rsquo;ve planned your app</h2>
+            <p>
+              You now have a <code>docs/planning/</code> folder of structured briefs — your
+              need statement, compliance brief, data model, and UX plan. That&rsquo;s everything
+              your AI coding agent needs to start building.
+            </p>
+            <p>
+              Ready for the next step? <code>spezi-platform-selection</code> picks React Native
+              or Apple-native and clones a matching Spezi template to build on.
+            </p>
+            <div className="ws-complete-links">
+              <a className="btn-primary" href="/docs/how-it-works">
+                See how building works
+              </a>
+              <a className="btn-secondary" href="/docs/skills/app-build-planner">
+                Sequence the build
+              </a>
+            </div>
+          </div>
+        )}
+      </section>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Workshop** tab — an interactive, in-browser stepper that takes a simple idea and walks the user through planning a digital health app.

### Workshop page (`/workshop`)
- Enter your app idea at the top — it's woven into every step's prompt and persisted in `localStorage`.
- Five steps (Install → Define the need → Plan compliance → Model data → Design UX), each with a number badge (active/done states), the skill → output it produces, a copy-paste prompt, and a "Mark done" toggle.
- Progress bar + Reset; completion card when all steps are done.
- Progress and idea survive a page reload.

### Try-in-Claude / Try-in-ChatGPT buttons
- Each skill step gets deeplink buttons that open the prompt in Claude or ChatGPT — same robust "fetch the SKILL.md from GitHub and run it" prompt the docs pages use, now personalized with the user's idea.
- Refactored `TryThisSkill.jsx` into reusable exports (`buildPrompt(skill, {context})` + `TryButtons`); the existing docs usage is unchanged.
- Uses the official Claude and OpenAI marks, with button colors aligned to each brand's current guidelines (Anthropic coral; OpenAI monochrome black).

### Wiring
- Workshop added to the navbar (Docs · Workshop · About) and the footer.

## Test plan
- [ ] `npm run build` in `docs/` succeeds (SSR-safe: browser APIs guarded)
- [ ] `/workshop` renders; entering an idea updates prompts; Mark done + progress persist across reload
- [ ] Try buttons open Claude/ChatGPT with the prompt prefilled
- [ ] Existing docs "Try this skill" buttons still work