### PR TITLE
Fix orchestration gaps and contradictions across skills

### DIFF
--- a/skills/app-build-planner/SKILL.md
+++ b/skills/app-build-planner/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when:
 
 Run this after the other planning skills and **before** `spezi-platform-selection`. The platform choice can be informed by what the plan reveals (HealthKit needs, cross-platform requirements, etc.).
 
-Do not use this skill if you have not done any planning work yet. Start with the planning skills first.
+Planning inputs make the plan much better, but they are not a hard requirement — if no planning documents exist, Step 1 falls back to asking the user to describe the app directly. Prefer running the planning skills first when the user has time for them.
 
 ## Working Style
 
@@ -39,7 +39,7 @@ You are a directive implementation planner. You synthesize planning outputs and 
 5. Sequence features into ordered milestones
 6. Produce the implementation plan document
 
-**All output is in chat.** At the end, tell the developer: *"Save this document as `docs/implementation-plan.md` in your project. Your coding agent will use it as the sequenced build plan — milestone by milestone."*
+**Save the deliverable to disk.** Write the finished plan to `docs/implementation-plan.md` in the project repository, then tell the developer: *"Your implementation plan is saved at `docs/implementation-plan.md`. Your coding agent will use it as the sequenced build plan — milestone by milestone."* If the current environment cannot write files (e.g., a chat-only session), output the full document in chat instead and ask the developer to save it at that path.
 
 ---
 
@@ -55,6 +55,7 @@ Check `docs/planning/` in the project repository for outputs from upstream plann
 | `health-data-model-planning` | `docs/planning/data-model-brief.md` | Data model brief: core entities, relationships, lifecycle states, FHIR recommendations |
 | `fhir-data-model-design` | `docs/planning/fhir-data-model.md` | FHIR spec: concrete resources, terminology bindings, resource relationships |
 | `digital-health-compliance-planning` | `docs/planning/compliance-brief.md` | Compliance brief: privacy domains, consent requirements, audit controls |
+| `fasten-ehr-integration` | `docs/planning/ehr-connection-brief.md` | EHR connection brief: Fasten Connect integration status, privacy and architecture decisions |
 
 Read each file that exists. For any that are missing, note the gap and move on.
 
@@ -113,7 +114,7 @@ For each feature, note:
 
 Also extract separately:
 
-- **Data entities** — if a `health-data-model-planning` or `fhir-data-model-design` document is available, list each data entity (e.g., Patient, Observation, QuestionnaireResponse) with its FHIR resource mapping. These feed the Data Model Integration table in the output document.
+- **Data entities** — if a `health-data-model-planning` or `fhir-data-model-design` document is available, list each data entity (e.g., Patient, Observation, QuestionnaireResponse) with its FHIR resource mapping. If both documents exist, treat `fhir-data-model.md` as authoritative for FHIR mappings — the data model brief's FHIR recommendations are preliminary. These feed the Data Model Integration table in the output document.
 - **Compliance controls** — if a `digital-health-compliance-planning` document is available, list each required control (e.g., "audit log all PHI access", "collect informed consent before data collection", "enforce data retention policy"). These feed the Compliance Integration table in the output document.
 
 ---
@@ -124,10 +125,10 @@ For each extracted feature, identify which pre-built packages (React Native) or 
 
 Use the reference files:
 
-- [react-native-packages.md](references/react-native-packages.md) — `@spezivibe/account`, `@spezivibe/onboarding`, `@spezivibe/questionnaire`, `@spezivibe/scheduler`, `@spezivibe/chat`, `@spezivibe/firebase`, `@spezivibe/medplum`
+- [react-native-packages.md](references/react-native-packages.md) — `@spezivibe/account`, `@spezivibe/onboarding`, `@spezivibe/questionnaire`, `@spezivibe/scheduler`, `@spezivibe/chat`, `@spezivibe/firebase`, `@spezivibe/medplum`, and `@spezivibe/healthkit` (not yet built — see its Status note)
 - [apple-native-modules.md](references/apple-native-modules.md) — SpeziAccount, SpeziOnboarding, SpeziQuestionnaire, SpeziScheduler, SpeziChat, SpeziHealthKit, SpeziFHIR, SpeziFirebaseAccount, SpeziFirestore, SpeziNotifications, SpeziViews
 
-Check the reference file's **Status** field for each package before recommending it. Some packages (notably `@spezivibe/healthkit`) are not yet built and should be flagged as requiring custom implementation.
+Read each package's entry in the reference file before recommending it — a **Status** note flags a package that is not ready for use. On React Native, `@spezivibe/healthkit` is not yet built, so features that depend on it must be flagged as requiring custom implementation. The Apple-native modules are all released Spezi packages.
 
 For features that have no matching package or module, note that they require custom implementation and estimate relative effort (small, medium, large).
 
@@ -180,7 +181,7 @@ Generate the full implementation plan document using this format:
 ```markdown
 # Implementation Plan: [App Name]
 
-> Generated by `app-build-planner`. Save as `docs/implementation-plan.md` in your project.
+> Generated by `app-build-planner`. Saved as `docs/implementation-plan.md` in your project.
 
 ## Context
 
@@ -257,7 +258,7 @@ Generate the full implementation plan document using this format:
 
 ## Next Steps
 
-Save this document as `docs/implementation-plan.md` in your project repository.
+This plan is saved as `docs/implementation-plan.md` in your project repository.
 
 To start building, work through the milestones one at a time with your coding
 agent. Each milestone is designed to be built and reviewed as a single focused
@@ -291,4 +292,4 @@ Before delivering the implementation plan, verify:
 - [ ] Custom implementation effort is noted for features without a matching package
 - [ ] Missing planning inputs are flagged
 - [ ] Open questions are listed
-- [ ] The handoff instruction tells the user where to save the document
+- [ ] The plan is saved to `docs/implementation-plan.md` (or, in a chat-only session, the user has been told to save it there)

--- a/skills/app-build-planner/references/milestone-patterns.md
+++ b/skills/app-build-planner/references/milestone-patterns.md
@@ -8,6 +8,8 @@ SPDX-License-Identifier: MIT
 
 Common milestone sequences for digital health app archetypes. Use these as starting templates and adapt based on the actual planning inputs.
 
+> **Package availability:** in the tables below, the React Native `healthkit` package (`@spezivibe/healthkit`) is **not yet built** — see [react-native-packages.md](react-native-packages.md). On React Native, plan health-data milestones as custom HealthKit integration work. The Apple-native `SpeziHealthKit` module is available.
+
 ## Research Study App
 
 Apps tied to a clinical or research study with defined enrollment, consent, assessments, and data collection.

--- a/skills/build-an-app/SKILL.md
+++ b/skills/build-an-app/SKILL.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
 
 # Build an App
 
-Walk a user through building a digital health app from start to finish. This skill orchestrates the other skills in this repository — it figures out what the user needs, runs the right planning skills, and hands off to implementation.
+Walk a user through building a digital health app from start to finish. This skill orchestrates the planning and build skills in this repository — it figures out what the user needs, runs the right planning skills, and hands off to implementation. (The release utilities `keep-a-changelog-generator` and `release-notes-generator` are used later in a project's life and are not part of this flow.)
 
 ## When to Use
 
@@ -76,6 +76,7 @@ Based on what you heard, assemble a plan from the available skills. Every skill 
 | `fasten-ehr-integration` | App needs patients to pull their own EHR records in via Fasten Connect |
 | `digital-health-study-planning` | App is part of a research study with enrollment and assessments |
 | `app-build-planner` | Always — produces the implementation plan that drives the build |
+| `project-wiki` | User wants a persistent knowledge base that grows with the project — also offered at the end of planning (Step 4) even if not selected here |
 
 Present the plan as a short numbered list with one line per skill explaining what it does. Then ask:
 
@@ -124,12 +125,14 @@ Between each skill, ask: "Ready to move on, or do you want to adjust anything?"
 
 ## Step 4: Start Building
 
-After `app-build-planner` saves `docs/implementation-plan.md`, summarize everything that was produced — only list documents that were actually created:
+Run this step only after **all** selected skills have completed. In particular, if `spezi-platform-selection` was selected, it must run before building starts — implementation happens inside the cloned template, not in the planning directory.
+
+Summarize everything that was produced — only list documents that were actually created:
 
 ```
 Here's what we have:
 
-Project: [cloned template path]
+Project: [cloned template path, or the current directory if no template was cloned]
 
 Planning documents:
   [list only the docs that were created]
@@ -141,7 +144,13 @@ Implementation plan:
 Ready to start building Milestone 1?
 ```
 
-If the user says yes, read `docs/implementation-plan.md`, find Milestone 1, and begin implementing it.
+If `project-wiki` was not already run, offer it once before the build starts:
+
+> "Would you like to set up a project wiki to keep accumulating knowledge as you build? It seeds from your planning documents and grows as you add interviews, papers, and clinical observations."
+
+If the user accepts, run the `project-wiki` skill (read its SKILL.md and follow its instructions), then return here.
+
+When the user is ready to build, read `docs/implementation-plan.md`, find Milestone 1, and begin implementing it.
 
 ---
 

--- a/skills/digital-health-compliance-planning/SKILL.md
+++ b/skills/digital-health-compliance-planning/SKILL.md
@@ -71,6 +71,8 @@ If the product supports a study, review:
 - de-identification or anonymization approach
 - data sharing and secondary use plans
 
+If `digital-health-study-planning` also runs, it owns the participant-facing consent and enrollment flow; this skill owns the regulatory requirements those flows must satisfy. Coordinate rather than duplicate.
+
 ### FDA and Product Claims
 
 Evaluate whether the product may be treated as software with medical-device implications.

--- a/skills/digital-health-study-planning/SKILL.md
+++ b/skills/digital-health-study-planning/SKILL.md
@@ -57,6 +57,8 @@ Work through:
 - consent requirements
 - participant withdrawal process
 
+This skill covers the participant-facing side of consent — who consents, when, and how it fits the study flow. `digital-health-compliance-planning` covers the regulatory side (IRB expectations, consent capture and versioning, de-identification); coordinate rather than duplicate if both skills run.
+
 Do not assume device ownership, app literacy, or language access without checking.
 
 ### 3. Data Collection Plan

--- a/skills/fhir-data-model-design/SKILL.md
+++ b/skills/fhir-data-model-design/SKILL.md
@@ -19,6 +19,8 @@ FHIR (Fast Healthcare Interoperability Resources) R4 is the standard for healthc
 
 The key challenge: FHIR has 140+ resource types, dozens of profiles, and many ways to model the same concept. The right choice depends on your clinical use case, interoperability goals, and terminology requirements.
 
+**Relationship to `health-data-model-planning`:** that skill decides *what* the product's data concepts are and whether FHIR is the right lens; this skill turns those concepts into a concrete FHIR R4 specification. If `docs/planning/data-model-brief.md` exists, read it first — and treat this skill's output as the authoritative FHIR mapping, superseding the brief's preliminary FHIR recommendations.
+
 **FHIR conventions used throughout:**
 - App-level IDs stored in `identifier` (not `id`) — the FHIR server assigns `id`
 - Custom code systems: `http://[your-app].com/fhir/CodeSystem/[name]`
@@ -38,7 +40,7 @@ You are an expert FHIR architect. You give concrete recommendations — specific
 5. Design resource relationships and data flows
 6. **Produce a structured data model specification document** — the primary deliverable
 
-**All output is in chat.** At the end, tell the developer: *"Save this document as `docs/fhir-data-model.md` in your project. Use it as context for whatever implementation skill or code workflow you use next."*
+**Save the deliverable to disk.** Write the finished specification to `docs/planning/fhir-data-model.md` in the project repository, then tell the developer: *"Your FHIR data model is saved at `docs/planning/fhir-data-model.md`. Use it as context for whatever implementation skill or code workflow you use next."* If the current environment cannot write files (e.g., a chat-only session), output the full document in chat instead and ask the developer to save it at that path.
 
 ---
 

--- a/skills/health-data-model-planning/SKILL.md
+++ b/skills/health-data-model-planning/SKILL.md
@@ -21,6 +21,8 @@ Use this skill when you need to:
 - reason about interoperability requirements with FHIR as the default starting point for clinical data
 - prepare for later implementation in a mobile app, backend, analytics pipeline, or research workflow
 
+**Relationship to `fhir-data-model-design`:** this skill plans the concepts — entities, relationships, lifecycle states, and whether FHIR fits. When the app needs a concrete FHIR R4 specification (specific resources, profiles, and terminology bindings), run `fhir-data-model-design` afterwards; its output supersedes this brief's preliminary FHIR recommendations.
+
 ## Working Style
 
 Start with the domain, but assume that clinically meaningful data will often benefit from a FHIR-oriented design unless there is a strong reason not to.

--- a/skills/keep-a-changelog-generator/SKILL.md
+++ b/skills/keep-a-changelog-generator/SKILL.md
@@ -18,7 +18,9 @@ Generate changelogs from git history following Keep a Changelog format.
 Use this skill when you need to:
 - Generate changelog entries for a release
 - Document changes since the last version
-- Create release notes from commits
+- Maintain a project's `CHANGELOG.md` file
+
+Use `release-notes-generator` instead when you need a narrative release announcement with highlights, usage examples, and migration guidance. This skill maintains the structured `CHANGELOG.md` file; that one writes the story of a single release.
 
 ## Changelog Format
 
@@ -79,7 +81,7 @@ git log v1.0.0..HEAD --oneline
 git log --format="%h %s%n%b" HEAD~10..HEAD
 
 # Commits since a date
-git log --since="2024-01-01" --oneline
+git log --since="2026-01-01" --oneline
 ```
 
 ## Writing Guidelines
@@ -103,7 +105,7 @@ Flag API changes clearly:
 ## Output Example
 
 ```markdown
-## [1.2.0] - 2024-01-14
+## [1.2.0] - 2026-01-14
 
 ### Added
 - New health data visualization screen

--- a/skills/project-wiki/SKILL.md
+++ b/skills/project-wiki/SKILL.md
@@ -141,6 +141,7 @@ Do not duplicate content — extract key facts, relationships, and open question
 Check whether an `AGENTS.md` or `CLAUDE.md` already exists at the project root.
 
 - **If one exists:** append a clearly scoped `## Project Wiki Schema` section to the existing file. Do not overwrite or remove any existing content — the file may contain instructions for other tools or skills.
+- **If both exist:** append the same section to both files so they stay in sync — many projects keep `AGENTS.md` and `CLAUDE.md` identical.
 - **If neither exists:** create a new `AGENTS.md` at the project root.
 
 The Project Wiki Schema section should describe:
@@ -274,11 +275,7 @@ A living list of open questions, organized by category. When a question gets ans
 
 ## Integration with build-an-app
 
-When `build-an-app` completes its planning phase, it should offer:
-
-> "Your planning documents are ready. Would you like to set up a project wiki to keep accumulating knowledge as you build? The wiki will seed from your planning docs and grow as you add interviews, papers, and clinical observations."
-
-If the user accepts, hand off to this skill.
+The `build-an-app` orchestrator offers this skill at the end of its planning phase, after the project directory is in its final location (i.e., after `spezi-platform-selection` has cloned a template, if one was selected). When invoked from that flow, seed the wiki from the planning documents listed above and skip any "Understand the Project" questions the planning documents already answer.
 
 ## Guardrails
 

--- a/skills/release-notes-generator/SKILL.md
+++ b/skills/release-notes-generator/SKILL.md
@@ -20,6 +20,8 @@ Use this skill when you need to:
 - Summarize changes for users/stakeholders
 - Document migration steps for breaking changes
 
+Use `keep-a-changelog-generator` instead when you need to maintain the project's `CHANGELOG.md` file. This skill writes the narrative announcement for a single release; that one keeps the structured, cumulative changelog.
+
 ## Release Notes Structure
 
 ```markdown

--- a/skills/spezi-platform-selection/SKILL.md
+++ b/skills/spezi-platform-selection/SKILL.md
@@ -23,8 +23,8 @@ Skip this skill if the user is not adopting a Spezi template — for example, th
 
 Read [setup-guide.md](references/setup-guide.md) before making the recommendation.
 
-- **React Native** — cross-platform (iOS + Android) from one codebase. Backed by the Spezi React Native Template App.
-- **Apple-native** — Swift / SwiftUI for iPhone, iPad, and Vision Pro. Backed by the Spezi Template Application for Apple Platforms.
+- **React Native** — cross-platform (iOS + Android) from one codebase. Backed by the [SpeziVibe React Native Template](https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate).
+- **Apple-native** — Swift / SwiftUI for iPhone, iPad, and Vision Pro. Backed by the [Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication) for Apple platforms.
 
 ## Ask First
 
@@ -75,6 +75,8 @@ Use the bundled clone helper instead of writing ad hoc clone commands:
 - React Native: `scripts/clone-template.sh react-native <destination>`
 - Apple-native: `scripts/clone-template.sh apple-native <destination>`
 
+The helper renames the clone's `origin` remote to `template`, so the user cannot accidentally push their project (and planning briefs) to the Stanford template repository. Before the user pushes, help them create their own repository and add it as `origin`.
+
 ## Carry Planning Forward
 
 If the current working directory contains a `docs/planning/` directory or a `docs/implementation-plan.md` produced by the other planning skills, **move them into the cloned repository** so the coding agent picks up the full plan from the right place:
@@ -88,7 +90,7 @@ Confirm with the user before moving. If the cloned repo already contains a `docs
 
 After the move:
 
-1. inspect the cloned repository's local instructions
+1. read the cloned repository's `README.md` and any agent instruction files (`AGENTS.md`, `CLAUDE.md`) so implementation follows the template's conventions
 2. continue implementation inside the cloned repository rather than in the original planning directory
 
 ## Output

--- a/skills/spezi-platform-selection/references/platform-decision.md
+++ b/skills/spezi-platform-selection/references/platform-decision.md
@@ -10,7 +10,7 @@ Choose between **React Native** and **Apple-native** based on the product's defi
 
 ## React Native
 
-Use the Spezi React Native Template App when:
+Use the [SpeziVibe React Native Template](https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate) when:
 
 - cross-platform support (iOS + Android) matters from the beginning
 - the app is mostly content, education, forms, questionnaires, scheduling, or chat

--- a/skills/spezi-platform-selection/references/setup-guide.md
+++ b/skills/spezi-platform-selection/references/setup-guide.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 
 The setup workflow routes developers to one of two starter templates:
 
-- **React Native** → Spezi React Native Template App
+- **React Native** → SpeziVibe React Native Template
 - **Apple-native** → Spezi Template Application for Apple Platforms
 
 Before cloning a template, help the user get their machine into a usable development state for the platform they chose.

--- a/skills/spezi-platform-selection/scripts/clone-template.sh
+++ b/skills/spezi-platform-selection/scripts/clone-template.sh
@@ -22,7 +22,7 @@ case "$PROJECT_NAME" in
   react-native)
     REMOTE_URL="https://github.com/StanfordSpezi/SpeziVibeReactNativeTemplate"
     ;;
-  apple-native|spezi-template)
+  apple-native)
     REMOTE_URL="https://github.com/StanfordSpezi/SpeziTemplateApplication"
     ;;
   *)
@@ -33,3 +33,12 @@ case "$PROJECT_NAME" in
 esac
 
 git clone "$REMOTE_URL" "$DESTINATION"
+
+# The user's project must not push to the Stanford template repository.
+git -C "$DESTINATION" remote rename origin template
+
+echo ""
+echo "Cloned $REMOTE_URL into $DESTINATION."
+echo "The template remains available as the 'template' remote."
+echo "Before pushing, create your own repository and add it as 'origin':"
+echo "  git -C $DESTINATION remote add origin <your-repository-url>"


### PR DESCRIPTION
## Summary

An audit of how the skills work together found several places where `build-an-app` and the skills it orchestrates contradict each other — in ways that break the flow when an agent follows the text literally. This PR fixes those seams without changing any skill's scope.

### Orchestration fixes

- **`build-an-app` Step 4 skipped platform selection.** It triggered right after `app-build-planner` and said to begin implementing Milestone 1 — before `spezi-platform-selection` had run, so the build would start in the bare planning directory with no template and no platform decision. Step 4 now runs only after all selected skills complete and says implementation happens inside the cloned template.
- **`project-wiki` declared a handoff the orchestrator never implemented.** Its "Integration with build-an-app" section said `build-an-app` *should* offer the wiki — dead text, since one skill can't retroactively instruct another. `build-an-app` now actually offers the wiki at the end of planning (matching the README's Step 6), and `project-wiki`'s section describes the handoff instead of prescribing it.
- **Chat-only output vs. file verification.** `app-build-planner` and `fhir-data-model-design` both said **"All output is in chat"**, while `build-an-app` verifies each skill's output was *saved* and downstream skills read the files. Both skills now save their deliverable (`docs/implementation-plan.md`, `docs/planning/fhir-data-model.md`) with an explicit fallback for chat-only environments.
- **`fhir-data-model-design` contradicted itself on its own output path** (`docs/fhir-data-model.md` at the top, `docs/planning/fhir-data-model.md` in the template). Standardized on `docs/planning/fhir-data-model.md` — the path `app-build-planner`, `project-wiki`, and the docs site all use.
- **`app-build-planner` was 'Always required' but refused to run without planning docs.** Its guardrail now documents the no-planning fallback its own Step 1 already had.
- **Reference-file consistency:** `milestone-patterns.md` recommended `@spezivibe/healthkit` in all three archetypes although `react-native-packages.md` says it is not yet built (now caveated); the "check the Status field" instruction only matched one package (now accurate for both platforms); `fasten-ehr-integration`'s brief was missing from `app-build-planner`'s inputs table (now added).

### Overlap disambiguation

- `health-data-model-planning` ↔ `fhir-data-model-design`: each now states its role (concept planning vs. concrete FHIR spec) and that the FHIR spec supersedes the brief's preliminary FHIR recommendations — `app-build-planner` gets the same tie-break rule.
- `keep-a-changelog-generator` ↔ `release-notes-generator`: the changelog skill no longer claims "create release notes"; each points to the other for the neighboring job.
- Study ↔ compliance planning: one line each clarifying who owns participant-facing consent vs. regulatory consent requirements.

### Safety fix in `clone-template.sh`

The clone left `origin` pointing at the Stanford template repo, and the flow then moves the user's planning briefs (potentially sensitive) into that clone — so the first `git push` would target the template. The script now renames `origin` → `template` and tells the user to add their own `origin`; the SKILL.md documents this. Also removed the undocumented `spezi-template` platform alias and fixed prose that referred to the React Native template by a name that matches no real repository (it's `SpeziVibeReactNativeTemplate`).

Deliberately left alone: the `project-wiki` README's overlap with its SKILL.md (it serves as the GitHub-facing landing page), and all `docs/` site content (separate concern).