### PR TITLE
Enforce skill, docs, and instruction-file invariants in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check skill structure
+      - name: Check skill structure and frontmatter
         run: |
           status=0
           for dir in skills/*/; do
@@ -47,6 +47,45 @@ jobs:
             if [ ! -f "$dir/SKILL.md" ]; then
               echo "::error::$skill is missing SKILL.md"
               status=1
+              continue
+            fi
+            name=$(awk '/^---$/{n++; next} n==1 && /^name:/{sub(/^name:[[:space:]]*/, ""); print; exit}' "$dir/SKILL.md")
+            description=$(awk '/^---$/{n++; next} n==1 && /^description:/{sub(/^description:[[:space:]]*/, ""); print; exit}' "$dir/SKILL.md")
+            if [ "$name" != "$skill" ]; then
+              echo "::error::$skill/SKILL.md frontmatter name is '$name' but the directory is '$skill'"
+              status=1
+            fi
+            if [ -z "$description" ]; then
+              echo "::error::$skill/SKILL.md frontmatter is missing a description"
+              status=1
             fi
           done
           exit $status
+      - name: Check docs pages stay in sync with skills
+        run: |
+          status=0
+          for dir in skills/*/; do
+            skill=$(basename "$dir")
+            if [ ! -f "docs/docs/skills/$skill.md" ]; then
+              echo "::error::$skill has no docs page at docs/docs/skills/$skill.md"
+              status=1
+            fi
+            if ! grep -q "skills/$skill" docs/sidebars.js; then
+              echo "::error::$skill is not listed in docs/sidebars.js"
+              status=1
+            fi
+          done
+          for page in docs/docs/skills/*.md; do
+            skill=$(basename "$page" .md)
+            if [ ! -d "skills/$skill" ]; then
+              echo "::error::$page has no matching skill directory"
+              status=1
+            fi
+          done
+          exit $status
+      - name: Check AGENTS.md and CLAUDE.md are identical
+        run: |
+          if ! diff -u AGENTS.md CLAUDE.md; then
+            echo "::error::AGENTS.md and CLAUDE.md have diverged — keep them identical"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,11 @@ SPDX-License-Identifier: MIT
 
 This repository contains shared installable skills for digital health development.
 
-## Key Area
+## Key Areas
 
 ```text
-skills/   Shared installable skills
+skills/   Shared installable skills — the source of truth for all skill content
+docs/     Docusaurus site published to spezivibe.com
 ```
 
 ## Expectations
@@ -21,6 +22,8 @@ skills/   Shared installable skills
 - Keep root-level skills reusable and broadly useful across digital health projects.
 - Prefer framework-agnostic guidance unless a skill is explicitly about platform selection.
 - Keep the repository focused on helping people choose a direction, plan well, and move faster with confidence.
+- When adding or renaming a skill, update the matching page in `docs/docs/skills/`, the entry in `docs/sidebars.js`, and the root `README.md` — CI checks that every skill has a docs page and sidebar entry.
+- Keep `AGENTS.md` and `CLAUDE.md` identical — CI enforces this.
 
 ## Entry Skill
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,11 @@ SPDX-License-Identifier: MIT
 
 This repository contains shared installable skills for digital health development.
 
-## Key Area
+## Key Areas
 
 ```text
-skills/   Shared installable skills
+skills/   Shared installable skills — the source of truth for all skill content
+docs/     Docusaurus site published to spezivibe.com
 ```
 
 ## Expectations
@@ -21,6 +22,8 @@ skills/   Shared installable skills
 - Keep root-level skills reusable and broadly useful across digital health projects.
 - Prefer framework-agnostic guidance unless a skill is explicitly about platform selection.
 - Keep the repository focused on helping people choose a direction, plan well, and move faster with confidence.
+- When adding or renaming a skill, update the matching page in `docs/docs/skills/`, the entry in `docs/sidebars.js`, and the root `README.md` — CI checks that every skill has a docs page and sidebar entry.
+- Keep `AGENTS.md` and `CLAUDE.md` identical — CI enforces this.
 
 ## Entry Skill
 


### PR DESCRIPTION
## Summary

The `validate-skills` CI job only checked that each skill directory contains a `SKILL.md` — none of the cross-cutting invariants that keep this repo coherent were enforced, so drift (like a skill missing its docs page, or `AGENTS.md`/`CLAUDE.md` diverging) could ship silently. This PR makes CI check:

- **Frontmatter validity** — each `SKILL.md` has a `name` matching its directory and a non-empty `description` (the invariant holds today, but nothing guarded it).
- **Docs ↔ skills sync** — every skill under `skills/` has a page at `docs/docs/skills/<name>.md` and an entry in `docs/sidebars.js`, and every docs skill page maps back to a real skill. All 13 current skills pass.
- **`AGENTS.md` ≡ `CLAUDE.md`** — the two files are byte-identical today but have been edited separately in the past; CI now fails if they diverge.

All checks were verified green against current `main` before adding them.

## Instruction-file updates

`CLAUDE.md`/`AGENTS.md` described `skills/` as the only key area, but `docs/` is now roughly half the tracked repository and drives spezivibe.com. Both files (kept identical) now list `docs/`, and document the expectations the new CI checks enforce: update the docs page, sidebar, and README when adding or renaming a skill, and keep the two instruction files in sync.

## Deliberately not changed

- `deploy-docs.yml`'s `paths: ['docs/**']` filter is actually correct: the built site's content lives entirely under `docs/` (the Try-this-skill buttons fetch SKILL.md from raw.githubusercontent.com at runtime), so skills-only commits don't change the build output. The drift risk it implied is covered by the new sync check instead.
- The REUSE/SPDX CI check was removed deliberately in an earlier commit, so it is not reinstated here.